### PR TITLE
[FIX] Hotfix for handling responses from n-API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,21 +281,31 @@ function App() {
     const url: string = constructQueryURL();
     try {
       const response = await axios.get(url);
-      setResult(response.data);
-      switch (response.data.nodes_response_status) {
-        case 'partial success': {
-          response.data.errors.forEach((error: NodeError) => {
-            enqueueSnackbar(`${error.node_name} failed to respond`, { variant: 'warning' });
-          });
-          break;
+      // TODO: remove this branch once there is no more non-federation option
+      if (isFederationAPI) {
+        setResult(response.data);
+        switch (response.data.nodes_response_status) {
+          case 'partial success': {
+            response.data.errors.forEach((error: NodeError) => {
+              enqueueSnackbar(`${error.node_name} failed to respond`, { variant: 'warning' });
+            });
+            break;
+          }
+          case 'fail': {
+            enqueueSnackbar('Error: All nodes failed to respond', { variant: 'error' });
+            break;
+          }
+          default: {
+            break;
+          }
         }
-        case 'fail': {
-          enqueueSnackbar('Error: All nodes failed to respond', { variant: 'error' });
-          break;
-        }
-        default: {
-          break;
-        }
+      } else {
+        const myResponse = {
+          responses: response.data,
+          nodes_response_status: 'success',
+          errors: [],
+        };
+        setResult(myResponse);
       }
     } catch (error) {
       enqueueSnackbar('Failed to retrieve results', { variant: 'error' });


### PR DESCRIPTION
Fixes #138
This is a temporary fix until we get rid of the
non-federated deployment option in general

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #138 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- this is a hotfix, we will get rid of the non-federation mode in the near future
- this just makes up a response body in the expected shape and sticks the n-API response inside
- also: didn't add any tests because that would require a complete additional e2e workflow (to run the stack with NB_IS_FEDERATION_API=false)

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
