### PR TITLE
[FIX] Change internal port to 5173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,13 @@ RUN chmod +x /entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 
-EXPOSE 80
+# Now we will define a custom port for the webserver (NGINX)
+# to listen on INSIDE of the container. The default port would
+# be port 80.
+ENV NGINX_PORT=5173
+RUN sed -i "s/listen[[:space:]]*80/listen ${NGINX_PORT}/g" /etc/nginx/conf.d/default.conf
+EXPOSE ${NGINX_PORT}
+
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 


### PR DESCRIPTION
Fixes #466

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #466

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Replace default port in the nginx config inside the container to 5173
- note: we could also just make that configurable, but maybe for later

:warning:  **Want to release of this PR**

**NOTE: If this pull request is to be released, the release label must be applied once the review process is done to avoid the local and remote from going out of sync as a consequence of the `bump version` workflow run**

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
