### PR TITLE
[FIX] Prevent previously selected pipeline version from appearing in the query after the field has been disabled

### DIFF
--- a/cypress/e2e/APIRequests.cy.ts
+++ b/cypress/e2e/APIRequests.cy.ts
@@ -400,13 +400,21 @@ describe('Successful API query requests', () => {
     cy.get('[data-cy="Maximum age-continuous-field"]').type('30');
     cy.get('[data-cy="Minimum number of imaging sessions-continuous-field"]').type('2');
     cy.get('[data-cy="Minimum number of phenotypic sessions-continuous-field"]').type('3');
+    // Assert that pipeline version doesn't sneak into the query if pipeline name is cleared
+    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
+    cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
+    cy.get('[data-cy="Pipeline name-categorical-field"]').clear();
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
+    cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
     cy.get('[data-cy="submit-query-button"]').click();
     cy.wait('@call')
       .its('request.url')
       .should('contain', 'min_age=10')
       .and('contain', 'max_age=30')
       .and('contain', 'min_num_imaging_sessions=2')
-      .and('contain', 'min_num_phenotypic_sessions=3');
+      .and('contain', 'min_num_phenotypic_sessions=3')
+      .and('not.contain', 'pipeline_version');
   });
 });
 

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -71,7 +71,22 @@ describe('App', () => {
       "Parkinson's disease"
     );
   });
-  it('Enables the pipeline version field once a pipeline name is selected and disables and empties it when the pipeline name field is cleared', () => {
+  it('Enables the pipeline version field once a pipeline name is selected', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/pipelines/np:fmriprep/versions',
+      },
+      pipelineVersionOptions
+    ).as('getPipelineVersionsOptions');
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
+    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
+    cy.wait('@getPipelineVersionsOptions');
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
+    cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
+  });
+  it('Should disable and clear the pipeline version field when the pipeline name field is cleared', () => {
     cy.intercept(
       {
         method: 'GET',

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -71,7 +71,7 @@ describe('App', () => {
       "Parkinson's disease"
     );
   });
-  it('Enables the pipeline version field once a pipeline name is selected', () => {
+  it('Enables the pipeline version field once a pipeline name is selected and disables and empties it when the pipeline name field is cleared', () => {
     cy.intercept(
       {
         method: 'GET',
@@ -85,6 +85,9 @@ describe('App', () => {
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
     cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
+    cy.get('[data-cy="Pipeline name-categorical-field"]').clear();
+    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
+    cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
   });
   it('should toggle the filter form visibility when clicking the button', () => {
     cy.viewport(800, 600); // Mobile/tablet viewport

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,8 +406,8 @@ function App() {
     );
     setQueryParam('assessment', assessmentTool, queryParams);
     setQueryParam('image_modal', imagingModality, queryParams);
-    setQueryParam('pipeline_version', pipelineVersion, queryParams);
     setQueryParam('pipeline_name', pipelineName, queryParams);
+    setQueryParam('pipeline_version', pipelineName ? pipelineVersion : null, queryParams);
 
     // Remove keys with empty values
     const keysToDelete: string[] = [];

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -220,7 +220,7 @@ function QueryForm({
               label="Pipeline version"
               options={[]}
               onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
-              inputValue={pipelineVersion}
+              inputValue={null}
               disabled
             />
           </div>


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #486 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added a condition in the `constructQueryURL` function to set `pipelineVersion` to null when no `pipelineName` is selected so it doesn't show up in the query
- Set the `inputValue` prop on the disabled to `null` so it is cleared when disabled
- Added tests for both

**NOTE: If this pull request is to be released, the release label must be applied once the review process is done to avoid the local and remote from going out of sync as a consequence of the `bump version` workflow run**

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Clear the pipeline version when the pipeline name is deselected.  This prevents including the pipeline version in the query when no pipeline is selected.

Bug Fixes:
- Prevent pipeline version from appearing in the query after the pipeline name field is cleared or disabled

Tests:
- Add tests to verify the fix prevents the pipeline version from appearing in the query when the pipeline name is cleared