### PR TITLE
[MNT] Changed `Flow Weighted` label and name to `Functional MRI`

### DIFF
--- a/cypress/e2e/ResultsTSV.cy.ts
+++ b/cypress/e2e/ResultsTSV.cy.ts
@@ -112,7 +112,7 @@ describe('Unprotected response', () => {
       expect(phenotypicSession.split('\t')[12]).to.equal('multisource interference task');
       expect(phenotypicSession.split('\t')[13]).to.equal('');
       expect(phenotypicSession.split('\t')[14]).to.equal('');
-      expect(phenotypicSession.split('\t')[15]).to.equal('Flow Weighted,T2 Weighted');
+      expect(phenotypicSession.split('\t')[15]).to.equal('Functional MRI,T2 Weighted');
       expect(phenotypicSession.split('\t')[16]).to.equal('fmriprep 23.1.3,freesurfer 7.3.2');
 
       expect(imagingSession.split('\t')[0]).to.equal('some dataset');
@@ -130,9 +130,9 @@ describe('Unprotected response', () => {
       expect(imagingSession.split('\t')[10]).to.equal('');
       expect(imagingSession.split('\t')[11]).to.equal('');
       expect(imagingSession.split('\t')[12]).to.equal('');
-      expect(imagingSession.split('\t')[13]).to.equal('Flow Weighted,T2 Weighted');
+      expect(imagingSession.split('\t')[13]).to.equal('Functional MRI,T2 Weighted');
       expect(imagingSession.split('\t')[14]).to.equal('fmriprep 23.1.3,freesurfer 7.3.2');
-      expect(imagingSession.split('\t')[15]).to.equal('Flow Weighted,T2 Weighted');
+      expect(imagingSession.split('\t')[15]).to.equal('Functional MRI,T2 Weighted');
       expect(imagingSession.split('\t')[16]).to.equal('fmriprep 23.1.3,freesurfer 7.3.2');
     });
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -50,9 +50,9 @@ export const modalities: {
     bgColor: 'rgb(253, 164, 164)',
   },
   'http://purl.org/nidash/nidm#FlowWeighted': {
-    label: 'Flow Weighted',
+    label: 'Functional MRI',
     TermURL: 'nidm:FlowWeighted',
-    name: 'Flow',
+    name: 'fMRI',
     bgColor: 'rgb(70, 130, 180)',
   },
   'http://purl.org/nidash/nidm#T1Weighted': {


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #59 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

**NOTE: If this pull request is to be released, the release label must be applied once the review process is done to avoid the local and remote from going out of sync as a consequence of the `bump version` workflow run**

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhancements:
- Rename 'Flow Weighted' to 'Functional MRI'