### PR TITLE
[MNT] Ensure typescript checks run before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 
 npx lint-staged
-
+# We have to run type checking here because if we run it only on the staged files
+# via lint-staged, it will not use our tsconfig and flag all kinds of false positives
+# see: https://github.com/microsoft/TypeScript/issues/27379#issuecomment-425245572
+npm run type:check

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
   "*.{ts,tsx}": ["npm run lint:check:file"],
-  "*": ["npm run format:check:file"]
+  "!(.*|.*/**)*": ["npm run format:check:file"]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:test": "vite &",
     "build": "tsc && vite build",
+    "type:check": "tsc --noEmit --skipLibCheck",
     "lint:check:file": "eslint --report-unused-disable-directives --max-warnings=0 --ext ts,tsx",
     "lint:check": "eslint --report-unused-disable-directives --max-warnings=0 --ext ts,tsx .",
     "lint:fix:file": "eslint --fix --ext ts,tsx",
@@ -15,7 +17,9 @@
     "format:fix": "prettier --write .",
     "format:check:file": "prettier --check",
     "format:check": "prettier --check .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:component": "cypress run --component",
+    "test:e2e": "cypress run --e2e"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:test": "vite &",
     "build": "tsc && vite build",
     "type:check": "tsc --noEmit --skipLibCheck",
     "lint:check:file": "eslint --report-unused-disable-directives --max-warnings=0 --ext ts,tsx",


### PR DESCRIPTION
Also change the lintstaged config to now exclude
any hidden files and folders for the format checks

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #599

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- run `tsc` before every commit
- do not run `.lintstaged` on any hidden files or directories (that begin with a `.`)

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enforce TypeScript compilation checks on every commit and tighten up staged file formatting by ignoring hidden files, while adding dedicated test scripts for development and Cypress testing.

Enhancements:
- Add a npm script to run TypeScript type checking without emitting output
- Introduce dedicated npm scripts for Cypress component and end-to-end tests
- Add a background-compatible development test script

CI:
- Update pre-commit Husky hook to run the TypeScript type check before committing
- Refine lint-staged configuration to exclude hidden files and directories from formatting checks