### PR TITLE
[FIX] Fixed the `Cannot select "All"` bug

### DIFF
--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -111,7 +111,7 @@ describe('App', () => {
     cy.get('[data-cy="filter-toggle-button"]').should('not.exist');
     cy.get('[data-cy="query-form-container"]').should('be.visible');
   });
-  it('Selects different values for nodes field', () => {
+  it('Selects different nodes in the nodes field', () => {
     cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type(
       'OpenNeur{downarrow}{enter}'
     );

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -1,4 +1,5 @@
 import {
+  nodeOptions,
   diagnosisOptions,
   pipelineOptions,
   pipelineVersionOptions,
@@ -6,6 +7,13 @@ import {
 
 describe('App', () => {
   beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/nodes',
+      },
+      nodeOptions
+    ).as('getNodes');
     cy.intercept(
       {
         method: 'GET',
@@ -21,7 +29,7 @@ describe('App', () => {
       pipelineOptions
     ).as('getPipelineOptions');
     cy.visit('/');
-    cy.wait(['@getDiagnosisOptions', '@getPipelineOptions']);
+    cy.wait(['@getNodes', '@getDiagnosisOptions', '@getPipelineOptions']);
 
     // TODO: remove this
     // Bit of a hacky way to close the auth dialog
@@ -102,5 +110,29 @@ describe('App', () => {
     cy.viewport(1200, 800); // Desktop viewport
     cy.get('[data-cy="filter-toggle-button"]').should('not.exist');
     cy.get('[data-cy="query-form-container"]').should('be.visible');
+  });
+  it('Selects different values for nodes field', () => {
+    cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type(
+      'OpenNeur{downarrow}{enter}'
+    );
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]').should('contain', 'OpenNeuro');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type('Quebec{downarrow}{enter}');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]')
+      .should('contain', 'Quebec')
+      .and('contain', 'OpenNeuro');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type('All{downarrow}{enter}');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]')
+      .should('not.contain', 'Quebec')
+      .and('not.contain', 'OpenNeuro');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]').should('contain', 'All');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type(
+      'OpenNeur{downarrow}{enter}'
+    );
+    cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type('Quebec{downarrow}{enter}');
+    cy.get('.MuiAutocomplete-clearIndicator').click();
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]')
+      .should('not.contain', 'Quebec')
+      .and('not.contain', 'OpenNeuro');
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]').should('contain', 'All');
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,6 +305,9 @@ function App() {
   function updateCategoricalQueryParams(fieldLabel: string, value: FieldInput) {
     switch (fieldLabel) {
       case 'Neurobagel graph':
+        // Cases are to identify whether "All" was
+        // 1. explicitly selected (by the user) i.e., "All" is at the end of the array
+        // 2. selected by default on startup or when the field is cleared i.e., "All" is the only option in the array
         if (Array.isArray(value)) {
           // When “All” is selected after some other nodes were already selected, strip all other options
           if (value.length > 1 && value[value.length - 1].label === 'All') {
@@ -318,7 +321,7 @@ function App() {
             break;
           }
 
-          // Since "All" is the default, we need to strip it from the list when other options are selected
+          // Since "All" is the default, we need to strip "All" from the list when any other option is selected
           const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
           setSearchParams({ node: withoutAll });
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,7 +306,7 @@ function App() {
     switch (fieldLabel) {
       case 'Neurobagel graph':
         if (Array.isArray(value)) {
-          // Case 1: User explicitly selected "All" after some other nodes were already selected
+          // Case 1: User explicitly selected "All" after some other nodes were already selected.
           // in this case "All" would be the last option in the array
           // Approach: keep "All", remove all other options
           if (value.length > 1 && value[value.length - 1].label === 'All') {
@@ -314,7 +314,7 @@ function App() {
             break;
           }
 
-          // Case 2: User clicked the "x" dismiss button to clear all options
+          // Case 2: User clicked the "x" dismiss button to clear all options.
           // in this case the selected options array would be empty
           // Approach: set "All" as the only option
           if (value.length === 0) {
@@ -322,9 +322,10 @@ function App() {
             break;
           }
 
-          // Case 3: User selected some nodes, but not "All"
+          // Case 3: User selected some nodes, but not "All" option.
           // in this case if "All" is present in the selected options array,
-          // "All" would be the first option in the array as the default and fallback option
+          // "All" would be the first option in the array leftover from being initially
+          // set as the default or set as the fallback option when all options were cleared
           // Approach: Remove "All" if it was in the selected options and keep the rest
           const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
           setSearchParams({ node: withoutAll });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -318,7 +318,7 @@ function App() {
             break;
           }
 
-          // strip "All" from the list if there are other options selected
+          // Since "All" is the default, we need to stip it from the list when other options selected
           const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
           setSearchParams({ node: withoutAll });
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,7 +306,7 @@ function App() {
     switch (fieldLabel) {
       case 'Neurobagel graph':
         if (Array.isArray(value)) {
-          // When “All” is selected, override any other options
+          // When “All” is selected after some other nodes were already selected, strip all other options
           if (value.length > 1 && value[value.length - 1].label === 'All') {
             setSearchParams({ node: ['All'] });
             break;
@@ -318,7 +318,7 @@ function App() {
             break;
           }
 
-          // Since "All" is the default, we need to stip it from the list when other options selected
+          // Since "All" is the default, we need to strip it from the list when other options are selected
           const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
           setSearchParams({ node: withoutAll });
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,15 +306,21 @@ function App() {
     switch (fieldLabel) {
       case 'Neurobagel graph':
         if (Array.isArray(value)) {
-          // If no option is selected default to All
+          // When “All” is selected, override any other options
+          if (value.length > 1 && value[value.length - 1].label === 'All') {
+            setSearchParams({ node: ['All'] });
+            break;
+          }
+
+          // default to “All” when nodes are cleared
           if (value.length === 0) {
             setSearchParams({ node: ['All'] });
-            // If any option beside All is selected, remove All
-          } else if (value.length > 1) {
-            setSearchParams({ node: value.filter((n) => n.label !== 'All').map((n) => n.label) });
-          } else {
-            setSearchParams({ node: value.map((n) => n.label) });
+            break;
           }
+
+          // strip "All" from the list if there are other options selected
+          const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
+          setSearchParams({ node: withoutAll });
         }
         break;
       case 'Sex':

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,23 +305,27 @@ function App() {
   function updateCategoricalQueryParams(fieldLabel: string, value: FieldInput) {
     switch (fieldLabel) {
       case 'Neurobagel graph':
-        // Cases are to identify whether "All" was
-        // 1. explicitly selected (by the user) i.e., "All" is at the end of the array
-        // 2. selected by default on startup or when the field is cleared i.e., "All" is the only option in the array
         if (Array.isArray(value)) {
-          // When “All” is selected after some other nodes were already selected, strip all other options
+          // Case 1: User explicitly selected "All" after some other nodes were already selected
+          // in this case "All" would be the last option in the array
+          // Approach: keep "All", remove all other options
           if (value.length > 1 && value[value.length - 1].label === 'All') {
             setSearchParams({ node: ['All'] });
             break;
           }
 
-          // default to “All” when nodes are cleared
+          // Case 2: User clicked the "x" dismiss button to clear all options
+          // in this case the selected options array would be empty
+          // Approach: set "All" as the only option
           if (value.length === 0) {
             setSearchParams({ node: ['All'] });
             break;
           }
 
-          // Since "All" is the default, we need to strip "All" from the list when any other option is selected
+          // Case 3: User selected some nodes, but not "All"
+          // in this case if "All" is present in the selected options array,
+          // "All" would be the first option in the array as the default and fallback option
+          // Approach: Remove "All" if it was in the selected options and keep the rest
           const withoutAll = value.filter((n) => n.label !== 'All').map((n) => n.label);
           setSearchParams({ node: withoutAll });
         }


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #134 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Fix the nodes field selection logic to ensure the “All” option overrides other selections and defaults when cleared, and add Cypress intercept and e2e tests to validate this behavior

Bug Fixes:
- Ensure selecting “All” in the nodes field overrides any other selected options and defaults to “All” when cleared

Enhancements:
- Refactor nodes field handler to separately manage “All” selection and strip it when other options are chosen

Tests:
- Add Cypress intercept for `/nodes` and include it in setup waits
- Add new E2E test to cover nodes field selection scenarios, including selecting and clearing “All” and other options