### PR TITLE
[FIX] Handle unknown imageing modalities gracefully

### DIFF
--- a/cypress/component/ResultContainer.cy.tsx
+++ b/cypress/component/ResultContainer.cy.tsx
@@ -67,7 +67,7 @@ describe('ResultContainer', () => {
       />
     );
     cy.get('[data-cy="card-https://someportal.org/datasets/ds0003"]').should('be.visible');
-    cy.get('[data-cy="card-https://someportal.org/datasets/ds0003"]').within(() => {
+    cy.get('[data-cy="modality-buttons"]').within(() => {
       // Should only show T1 button, not the unknown modality
       cy.contains('button', 'T1').should('be.visible');
       cy.get('button').should('have.length', 1);

--- a/cypress/component/ResultContainer.cy.tsx
+++ b/cypress/component/ResultContainer.cy.tsx
@@ -1,5 +1,5 @@
 import ResultContainer from '../../src/components/ResultContainer';
-import { protectedResponse2 } from '../fixtures/mocked-responses';
+import { protectedResponse2, responseWithUnknownModality } from '../fixtures/mocked-responses';
 
 describe('ResultContainer', () => {
   it('Displays a set of Result Cards, select all checkbox, a disabled download result button, summary stats, and how to get data dialog button', () => {
@@ -57,5 +57,20 @@ describe('ResultContainer', () => {
     cy.get('[data-cy="default-result-container-view"]')
       .should('be.visible')
       .should('contain', "Click 'Submit Query' for results");
+  });
+  it('Handles unknown modalities gracefully without breaking', () => {
+    cy.mount(
+      <ResultContainer
+        response={responseWithUnknownModality}
+        assessmentOptions={[]}
+        diagnosisOptions={[]}
+      />
+    );
+    cy.get('[data-cy="card-https://someportal.org/datasets/ds0003"]').should('be.visible');
+    cy.get('[data-cy="card-https://someportal.org/datasets/ds0003"]').within(() => {
+      // Should only show T1 button, not the unknown modality
+      cy.contains('button', 'T1').should('be.visible');
+      cy.get('button').should('have.length', 1);
+    });
   });
 });

--- a/cypress/component/ResultContainer.cy.tsx
+++ b/cypress/component/ResultContainer.cy.tsx
@@ -68,7 +68,7 @@ describe('ResultContainer', () => {
     );
     cy.get('[data-cy="card-https://someportal.org/datasets/ds0003"]').should('be.visible');
     cy.get('[data-cy="modality-buttons"]').within(() => {
-      // Should only show T1 button, not the unknown modality
+      // Should show only one button (T1) button, and not the unknown modality
       cy.contains('button', 'T1').should('be.visible');
       cy.get('button').should('have.length', 1);
     });

--- a/cypress/fixtures/mocked-responses.ts
+++ b/cypress/fixtures/mocked-responses.ts
@@ -346,3 +346,25 @@ export const failedPipelineVersionOptions = {
     },
   ],
 };
+
+export const datasetWithUnknownModality = {
+  records_protected: false,
+  node_name: 'some-node-name',
+  dataset_uuid: 'https://someportal.org/datasets/ds0003',
+  dataset_name: 'dataset with unknown modality',
+  dataset_portal_uri: 'https://example.com/dataset',
+  dataset_total_subjects: 50,
+  num_matching_subjects: 5,
+  subject_data: 'protected',
+  image_modals: [
+    'http://purl.org/nidash/nidm#T1Weighted',
+    'http://purl.org/nidash/nidm#UnknownModality',
+  ],
+  available_pipelines: {},
+};
+
+export const responseWithUnknownModality = {
+  errors: [],
+  responses: [datasetWithUnknownModality],
+  nodes_response_status: 'success',
+};

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -125,11 +125,11 @@ const ResultCard = memo(
               </Tooltip>
             )}
           </div>
-          <div className="justify-self-end">
+          <div className="justify-self-end" data-cy="modality-buttons">
             <ButtonGroup>
               {imageModals
                 .sort()
-                .filter((modal) => modalities[modal])
+                .filter((modal) => Object.keys(modalities).includes(modal))
                 .map((modal) => (
                   <Button
                     key={modal}

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -127,22 +127,25 @@ const ResultCard = memo(
           </div>
           <div className="justify-self-end">
             <ButtonGroup>
-              {imageModals.sort().map((modal) => (
-                <Button
-                  key={modal}
-                  variant="contained"
-                  disableElevation
-                  sx={{
-                    backgroundColor: modalities[modal].bgColor,
-                    '&:hover': {
+              {imageModals
+                .sort()
+                .filter((modal) => modalities[modal])
+                .map((modal) => (
+                  <Button
+                    key={modal}
+                    variant="contained"
+                    disableElevation
+                    sx={{
                       backgroundColor: modalities[modal].bgColor,
-                      cursor: 'default',
-                    },
-                  }}
-                >
-                  {modalities[modal].name}
-                </Button>
-              ))}
+                      '&:hover': {
+                        backgroundColor: modalities[modal].bgColor,
+                        cursor: 'default',
+                      },
+                    }}
+                  >
+                    {modalities[modal].name}
+                  </Button>
+                ))}
             </ButtonGroup>
           </div>
         </div>


### PR DESCRIPTION

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #642 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Filter out unsupported imaging modalities in result cards and add tests to ensure unknown modalities are handled without breaking the UI

Bug Fixes:
- Exclude unknown modalities from rendering in ResultCard to prevent undefined lookup errors

Tests:
- Add Cypress fixtures and a component test to verify only recognized modalities are displayed when unknown modalities are present