### PR TITLE
[ENH] Add npm plugin to auto

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -15,6 +15,12 @@
                 "subject": "[pre-commit.ci]",
                 "labels": ["_bot", "skip-release"]
             }
+        ],
+        [
+            "npm",
+            {
+                "setRcToken": false
+            }
         ]
     ],
     "labels": [


### PR DESCRIPTION
This should now enable npm to bump the version in package.json during a release.

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #588

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add `npm` plugin to auto config
- Because we have `private: true`, npm will not publish even if we did configure it: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#private
- auto should take care of all steps, including bumping version in package.json on the next release
- not sure how we would easily test this before a release 

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhancements:
- Add npm plugin to auto configuration for automatic package.json version bump on release