### PR TITLE
[FIX] Remove git-tag from release wf

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -5,7 +5,6 @@
     "author": "Neurobagel Bot <bot@neurobagel.org>",
     "noVersionPrefix": false,
     "plugins": [
-        "git-tag",
         "released",
         "first-time-contributor",
         [
@@ -21,8 +20,7 @@
             {
                 "setRcToken": false,
                 "exact": true,
-                "commitNextVersion": true,
-                "publishFolder": "dist"
+                "forcePublish": false
             }
         ]
     ],

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-git-tag-version=false


### PR DESCRIPTION
Handle git tag creation with the npm plugin
This should hopefully fix our problem
with the package.json files not getting
bumped on release

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #588

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- remove git-tag auto plugin
- hand over all responsibility to npm plugin
- should :crossed_fingers: bump package.json on release

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Remove the standalone git-tag auto plugin and .npmrc file and delegate all release versioning and tag creation to the npm release plugin to ensure package.json is bumped correctly.

Bug Fixes:
- Ensure package.json version is bumped on release by using the npm plugin for git tag creation

Build:
- Delete leftover .npmrc file now that npm plugin handles tagging

CI:
- Remove git-tag auto plugin configuration from the release workflow