### PR TITLE
[MNT] Switch to using Apptainer command in "How to get data" instructions

### DIFF
--- a/cypress/component/GetDataDialog.cy.tsx
+++ b/cypress/component/GetDataDialog.cy.tsx
@@ -25,16 +25,16 @@ describe('GetDataDialog', () => {
     cy.get('@onCloseSpy').should('have.been.called');
   });
 
-  it('Switches between docker and singularity commands', () => {
+  it('Switches between docker and apptainer commands', () => {
     cy.mount(<GetDataDialog open={props.open} onClose={props.onClose} />);
 
     cy.get('button').contains('docker').should('exist');
-    cy.get('button').contains('singularity').should('exist');
+    cy.get('button').contains('apptainer').should('exist');
 
     cy.get('pre').should('contain', 'docker run');
 
-    cy.get('button').contains('singularity').click();
-    cy.get('pre').should('contain', 'singularity run');
+    cy.get('button').contains('apptainer').click();
+    cy.get('pre').should('contain', 'apptainer run');
 
     cy.get('button').contains('docker').click();
     cy.get('pre').should('contain', 'docker run');

--- a/src/components/GetDataDialog.tsx
+++ b/src/components/GetDataDialog.tsx
@@ -17,8 +17,8 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
   const RUN_COMMANDS: { [key: string]: string } = {
     docker:
       'docker run -t -u $(id -u):$(id -g) -v $(pwd):/data neurobagel/dataget:latest /data/neurobagel-query-results.tsv /data/output',
-    singularity:
-      'singularity run --bind $(pwd):/data docker://neurobagel/dataget:latest /data/neurobagel-query-results.tsv /data/output',
+    apptainer:
+      'apptainer run --bind $(pwd):/data docker://neurobagel/dataget:latest /data/neurobagel-query-results.tsv /data/output',
   };
 
   const theme = useTheme();
@@ -57,7 +57,7 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
           aria-label="Platform"
         >
           <ToggleButton value="docker">docker</ToggleButton>
-          <ToggleButton value="singularity">singularity</ToggleButton>
+          <ToggleButton value="apptainer">apptainer</ToggleButton>
         </ToggleButtonGroup>
         <DialogContentText>
           <CodeBlock code={RUN_COMMANDS[commandType]} />


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #661  

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Switch the “How to get data” instructions and tests to use Apptainer instead of Singularity

Enhancements:
- Replace Singularity with Apptainer for the data retrieval run command in the GetDataDialog component

Tests:
- Update component tests to assert on the apptainer toggle and run command instead of singularity