### PR TITLE
[FIX] Fix overlapping imaging modality and derivative group buttons and improve ResultCard responsiveness 

### DIFF
--- a/cypress/component/ResultCard.cy.tsx
+++ b/cypress/component/ResultCard.cy.tsx
@@ -291,7 +291,7 @@ describe('ResultCard', () => {
     // We target the container that holds both to ensure we check them together
     cy.get('[data-cy="modality-buttons"]').parent().as('container');
 
-    cy.get('@container').find('button').should('have.length.at.least', 5);
+    cy.get('@container').find('button').should('have.length', 6);
 
     cy.get('@container')
       .find('button')

--- a/cypress/component/ResultCard.cy.tsx
+++ b/cypress/component/ResultCard.cy.tsx
@@ -27,7 +27,7 @@ const props = {
   access_email: 'someemail@domain.com',
   access_link: 'https://example.com',
   checked: true,
-  onCheckboxChange: () => { },
+  onCheckboxChange: () => {},
   imagingModalitiesMetadata: {
     'http://purl.org/nidash/nidm#ArterialSpinLabeling': {
       TermURL: 'nidm:ArterialSpinLabeling',

--- a/cypress/component/ResultCard.cy.tsx
+++ b/cypress/component/ResultCard.cy.tsx
@@ -247,7 +247,7 @@ describe('ResultCard', () => {
   });
   it('should display modalities and pipelines without overlap and wrap correctly on smaller screens', () => {
     // Force a small viewport to ensure wrapping occurs
-    cy.viewport(500, 800);
+    cy.viewport(768, 900);
 
     const crowdedProps = {
       ...props,

--- a/src/components/ResultCard/DatasetInfoColumn.tsx
+++ b/src/components/ResultCard/DatasetInfoColumn.tsx
@@ -30,7 +30,7 @@ function DatasetInfoColumn({
         data-cy={`card-${datasetUuid}-checkbox`}
         checked={checked}
         onChange={() => onCheckboxChange(datasetUuid)}
-        sx={{ p: 0.5, alignSelf: 'flex-start' }}
+        sx={{ p: 0.5, alignSelf: 'center' }}
       />
       <Stack spacing={0.5} sx={{ minWidth: 0 }}>
         {/* Dataset Name (Text Only) */}
@@ -62,7 +62,7 @@ function DatasetInfoColumn({
                   data-cy={`card-${datasetUuid}-homepage-icon`}
                   size="small"
                   color="primary"
-                  style={{ padding: 4 }}
+                  style={{ padding: 4, marginLeft: -4 }}
                   href={homepage}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -74,7 +74,7 @@ function DatasetInfoColumn({
                   size="small"
                   disabled
                   color="primary"
-                  style={{ padding: 4 }}
+                  style={{ padding: 4, marginLeft: -4 }}
                   data-cy={`card-${datasetUuid}-homepage-icon`}
                 >
                   <HomeIcon fontSize="medium" />

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -51,7 +51,7 @@ const ResultCard = memo(
         <ResultCardHeader nodeName={nodeName} recordsProtected={recordsProtected} />
 
         <CardContent>
-          <div className="grid grid-cols-12 gap-4">
+          <div className="grid grid-cols-12 items-center gap-4">
             <div className="col-span-5 flex gap-2">
               <DatasetInfoColumn
                 datasetUuid={datasetUuid}

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -66,24 +66,26 @@ const ResultCard = memo(
             </div>
 
             <div
-              className="col-span-7 flex flex-wrap items-center justify-between gap-4"
+              className="col-span-7 flex items-center justify-between gap-4"
               data-cy="result-card-flex-container"
             >
-              <div className="flex items-center gap-2">
+              <div className="flex flex-col items-start text-left">
                 <SubjectCountColumn
                   numMatchingSubjects={numMatchingSubjects}
                   datasetTotalSubjects={datasetTotalSubjects}
                 />
               </div>
-              <ImagingModalitiesColumn
-                imageModals={imageModals}
-                imagingModalitiesMetadata={imagingModalitiesMetadata}
-                datasetUuid={datasetUuid}
-              />
-              <DerivativeDataColumn
-                availablePipelines={availablePipelines}
-                datasetUuid={datasetUuid}
-              />
+              <div className="flex flex-col items-start gap-2">
+                <ImagingModalitiesColumn
+                  imageModals={imageModals}
+                  imagingModalitiesMetadata={imagingModalitiesMetadata}
+                  datasetUuid={datasetUuid}
+                />
+                <DerivativeDataColumn
+                  availablePipelines={availablePipelines}
+                  datasetUuid={datasetUuid}
+                />
+              </div>
             </div>
           </div>
 

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -72,15 +72,12 @@ const ResultCard = memo(
               />
             </div>
 
-            <div className="col-span-2 flex flex-wrap content-center justify-center gap-1">
+            <div className="col-span-4 flex flex-wrap content-center justify-end gap-2">
               <ImagingModalitiesColumn
                 imageModals={imageModals}
                 imagingModalitiesMetadata={imagingModalitiesMetadata}
                 datasetUuid={datasetUuid}
               />
-            </div>
-
-            <div className="col-span-2 flex flex-col items-end justify-center">
               <DerivativeDataColumn
                 availablePipelines={availablePipelines}
                 datasetUuid={datasetUuid}

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -65,14 +65,16 @@ const ResultCard = memo(
               />
             </div>
 
-            <div className="col-span-3 flex flex-col justify-center">
-              <SubjectCountColumn
-                numMatchingSubjects={numMatchingSubjects}
-                datasetTotalSubjects={datasetTotalSubjects}
-              />
-            </div>
-
-            <div className="col-span-4 flex flex-wrap content-center justify-end gap-2">
+            <div
+              className="col-span-7 flex flex-wrap items-center justify-between gap-4"
+              data-cy="result-card-flex-container"
+            >
+              <div className="flex items-center gap-2">
+                <SubjectCountColumn
+                  numMatchingSubjects={numMatchingSubjects}
+                  datasetTotalSubjects={datasetTotalSubjects}
+                />
+              </div>
               <ImagingModalitiesColumn
                 imageModals={imageModals}
                 imagingModalitiesMetadata={imagingModalitiesMetadata}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #705 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Update result card layout to use unified 3-column layout

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Unify the ResultCard layout to improve responsiveness and prevent overlap between imaging modality and derivative pipeline buttons on smaller screens.

Bug Fixes:
- Prevent imaging modality and derivative pipeline buttons from overlapping by restructuring the ResultCard layout.

Enhancements:
- Adopt a unified flex-based layout for subject counts, imaging modalities, and derivative data to behave better across screen sizes.

Tests:
- Add a Cypress component test that verifies modality and pipeline buttons wrap correctly without overlap on small viewports.