### PR TITLE
chore: set up mock result cards for demo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,60 @@ function App() {
 
   const [loading, setLoading] = useState<boolean>(false);
 
-  const [result, setResult] = useState<DatasetsResponse | null>(null);
+  /*
+   * Mock data for demo purposes
+   * This allows us to see how the result card looks with all props and with missing props
+   */
+  const MOCK_DATASETS_RESPONSE: DatasetsResponse = {
+    nodes_response_status: 'success',
+    errors: [],
+    responses: [
+      {
+        node_name: 'OpenNeuro',
+        dataset_uuid: 'mock-ds-full-props',
+        dataset_name: 'Some Dataset',
+        authors: ['Alice A.', 'Bob B.', 'Charlie C.'],
+        homepage: 'https://openneuro.org/datasets/mock',
+        references_and_links: ['https://doi.org/10.1234/5678', 'https://paper.link/1'],
+        keywords: ['fMRI', 'neuroimaging', 'bids', 'mock'],
+        repository_url: 'https://github.com/OpenNeuro/mock',
+        access_instructions: 'Data is public domain. Please enjoy responsibily.',
+        access_type: 'public',
+        access_email: 'support@openneuro.org',
+        access_link: 'https://openneuro.org',
+        dataset_total_subjects: 120,
+        records_protected: false,
+        num_matching_subjects: 42,
+        image_modals: [
+          'http://purl.org/nidash/nidm#T1Weighted',
+          'http://purl.org/nidash/nidm#FlowWeighted',
+          'http://purl.org/nidash/nidm#T2Weighted',
+        ],
+        available_pipelines: { fmriprep: ['20.2.1', '21.0.0'], mriqc: ['0.16.1'] },
+      },
+      {
+        node_name: 'Austrian Neuro Cloud',
+        dataset_uuid: 'mock-ds-missing-props',
+        dataset_name: 'Some Other Dataset',
+        authors: [],
+        homepage: null,
+        references_and_links: [],
+        keywords: [],
+        repository_url: null,
+        access_instructions: null,
+        access_type: null,
+        access_email: null,
+        access_link: null,
+        dataset_total_subjects: 0,
+        records_protected: false,
+        num_matching_subjects: 0,
+        image_modals: [],
+        available_pipelines: {},
+      },
+    ],
+  };
+
+  const [result, setResult] = useState<DatasetsResponse | null>(MOCK_DATASETS_RESPONSE);
   const [resultStatus, setResultStatus] = useState<string>('success');
 
   const [minAge, setMinAge] = useState<string>('');


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhancements:
- Add comprehensive mock dataset responses covering both fully populated and sparsely populated result cards for UI demonstration and validation.