### PR TITLE
[ENH] Update command and docstring

### DIFF
--- a/src/components/GetDataDialog.tsx
+++ b/src/components/GetDataDialog.tsx
@@ -46,11 +46,12 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
               results&rdquo; dropdown
             </li>
             <li>Change directory to the location of the downloaded TSV</li>
-            <li>Take note of the filename you downloaded. It will include a timestamp at the end</li>
             <li>
-              Copy the below command into your terminal and replace the
-              &rdquo;YYYYMMDDHHMMSS&rdquo; placeholder with the actual time stamp 
-              from your downloaded filename
+              Take note of the filename you downloaded. It will include a timestamp at the end
+            </li>
+            <li>
+              Copy the below command into your terminal and replace the &rdquo;YYYYMMDDHHMMSS&rdquo;
+              placeholder with the actual time stamp from your downloaded filename
             </li>
             <li>Run the command</li>
           </ol>

--- a/src/components/GetDataDialog.tsx
+++ b/src/components/GetDataDialog.tsx
@@ -16,7 +16,7 @@ import CodeBlock from './CodeBlock';
 function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const RUN_COMMANDS: { [key: string]: string } = {
     docker:
-      'docker run -t -u $(id -u):$(id -g) -v $(pwd):/data neurobagel/dataget:latest /data/neurobagel-query-results_00000000000000.tsv /data/output',
+      'docker run -t -u $(id -u):$(id -g) -v $(pwd):/data neurobagel/dataget:latest /data/neurobagel-query-results_YYYYMMDDHHMMSS.tsv /data/output',
     apptainer:
       'apptainer run --bind $(pwd):/data docker://neurobagel/dataget:latest /data/neurobagel-query-results_00000000000000.tsv /data/output',
   };
@@ -46,9 +46,9 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
               results&rdquo; dropdown
             </li>
             <li>Change directory to the location of the downloaded TSV</li>
-            <li>Take not of the filename you downloaded. It will include a timestamp at the end</li>
+            <li>Take note of the filename you downloaded. It will include a timestamp at the end</li>
             <li>
-              Copy the command below into your terminal and replace the
+              Copy the below command into your terminal and replace the
               &rdquo;neurobagel-query-results_00000000000000.tsv&rdquo; placeholder with your actual
               file name. Make sure to keep the &rdquo;/data/&rdquo; part!
             </li>

--- a/src/components/GetDataDialog.tsx
+++ b/src/components/GetDataDialog.tsx
@@ -49,8 +49,8 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
             <li>Take note of the filename you downloaded. It will include a timestamp at the end</li>
             <li>
               Copy the below command into your terminal and replace the
-              &rdquo;neurobagel-query-results_00000000000000.tsv&rdquo; placeholder with your actual
-              file name. Make sure to keep the &rdquo;/data/&rdquo; part!
+              &rdquo;YYYYMMDDHHMMSS&rdquo; placeholder with the actual time stamp 
+              from your downloaded filename
             </li>
             <li>Run the command</li>
           </ol>

--- a/src/components/GetDataDialog.tsx
+++ b/src/components/GetDataDialog.tsx
@@ -16,9 +16,9 @@ import CodeBlock from './CodeBlock';
 function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const RUN_COMMANDS: { [key: string]: string } = {
     docker:
-      'docker run -t -u $(id -u):$(id -g) -v $(pwd):/data neurobagel/dataget:latest /data/neurobagel-query-results.tsv /data/output',
+      'docker run -t -u $(id -u):$(id -g) -v $(pwd):/data neurobagel/dataget:latest /data/neurobagel-query-results_00000000000000.tsv /data/output',
     apptainer:
-      'apptainer run --bind $(pwd):/data docker://neurobagel/dataget:latest /data/neurobagel-query-results.tsv /data/output',
+      'apptainer run --bind $(pwd):/data docker://neurobagel/dataget:latest /data/neurobagel-query-results_00000000000000.tsv /data/output',
   };
 
   const theme = useTheme();
@@ -46,7 +46,13 @@ function GetDataDialog({ open, onClose }: { open: boolean; onClose: () => void }
               results&rdquo; dropdown
             </li>
             <li>Change directory to the location of the downloaded TSV</li>
-            <li>Copy and run the command below</li>
+            <li>Take not of the filename you downloaded. It will include a timestamp at the end</li>
+            <li>
+              Copy the command below into your terminal and replace the
+              &rdquo;neurobagel-query-results_00000000000000.tsv&rdquo; placeholder with your actual
+              file name. Make sure to keep the &rdquo;/data/&rdquo; part!
+            </li>
+            <li>Run the command</li>
           </ol>
         </DialogContentText>
         <ToggleButtonGroup


### PR DESCRIPTION
To reflect the new timestamp

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #716 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Update the data download dialog to reference the timestamped query results file and clarify how to use it in the provided container commands.

Enhancements:
- Adjust Docker and Apptainer example commands to use a timestamped neurobagel query results filename placeholder.
- Improve the step-by-step instructions in the Get Data dialog to explain replacing the placeholder filename with the actual downloaded TSV before running the command.