### PR TITLE
[ENH] Implement visualization for catalog datasets

### DIFF
--- a/cypress/component/ResultCard.cy.tsx
+++ b/cypress/component/ResultCard.cy.tsx
@@ -59,7 +59,8 @@ describe('ResultCard', () => {
     cy.get('[data-cy="card-some uuid"]').should('contain', 'some node name node');
     cy.get('[data-cy="card-some uuid"]').should('contain', 'John Doe, Jane Doe, Bob Smith et al.');
     cy.get('[data-cy="card-some uuid"]').should('contain', 'Matching subjects:');
-    cy.get('[data-cy="card-some uuid"]').should('contain', '5 / 10');
+    cy.get('[data-cy="card-some uuid"]').should('contain', '5');
+    cy.get('[data-cy="card-some uuid"]').should('contain', '/ 10');
     cy.get('[data-cy="card-some uuid-checkbox"] input').should('be.checked');
     cy.get('[data-cy="card-some uuid-ASL-imaging-modality-button"]')
       .should('be.visible')
@@ -326,5 +327,34 @@ describe('ResultCard', () => {
           'Items should wrap to a new line on smaller screens'
         );
       });
+  });
+
+  it('Displays catalog dataset correctly with specific icons and unknown subjects', () => {
+    const catalogProps = {
+      ...props,
+      num_matching_subjects: null,
+    };
+
+    cy.mount(
+      <ResultCard
+        dataset={catalogProps}
+        imagingModalitiesMetadata={catalogProps.imagingModalitiesMetadata}
+        checked={catalogProps.checked}
+        onCheckboxChange={catalogProps.onCheckboxChange}
+      />
+    );
+
+    // SubjectCountColumn logic for catalog
+    cy.get('[data-cy="card-some uuid"]').should('contain', 'Matching subjects:');
+    cy.get('[data-cy="card-some uuid"]').should('contain', 'Unknown / 10');
+    cy.contains('Unknown').should('have.css', 'font-style', 'italic');
+
+    // ResultCardHeader logic for catalog
+    cy.get('[data-testid="MenuBookIcon"]').should('be.visible');
+
+    // Check tooltip (trigger mouseover on the icon wrapper)
+    // The icon is wrapped in a div with ml-1 flex items-center gap-1
+    cy.get('[data-testid="MenuBookIcon"]').parent().trigger('mouseover', { force: true });
+    cy.get('.MuiTooltip-tooltip').should('contain', 'Catalog-Level Dataset (No Subject Data)');
   });
 });

--- a/cypress/component/ResultContainer.cy.tsx
+++ b/cypress/component/ResultContainer.cy.tsx
@@ -49,7 +49,7 @@ describe('ResultContainer', () => {
     cy.get('[data-cy="select-all-checkbox"]').should('be.visible');
     cy.get('[data-cy="summary-stats"]')
       .should('be.visible')
-      .should('contain', 'Summary stats: 2 datasets, 4 subjects');
+      .should('contain', 'Summary stats: 2 datasets, 4 matching subjects, 20 total subjects');
     cy.get('[data-cy="download-results-button"]').should('be.visible').should('be.disabled');
   });
   it('Selecting a dataset should enable the download result button', () => {
@@ -163,5 +163,75 @@ describe('ResultContainer', () => {
     cy.get('@onDownloadSpy').should('have.been.calledWith', 0, [
       'https://someportal.org/datasets/ds0001',
     ]);
+  });
+
+  it('Filters out catalog datasets when the subject-level only switch is toggled', () => {
+    const mixedDatasetsResponse = {
+      errors: [],
+      nodes_response_status: 'success',
+      responses: [
+        { ...protectedResponse2.responses[0] },
+        {
+          ...protectedResponse2.responses[1],
+          dataset_uuid: 'catalog-1',
+          num_matching_subjects: null,
+          dataset_total_subjects: 150,
+        },
+      ],
+    };
+
+    cy.mount(
+      <ResultContainer
+        datasetsResponse={mixedDatasetsResponse}
+        assessmentOptions={[]}
+        diagnosisOptions={[]}
+        imagingModalitiesMetadata={imagingModalitiesMetadata}
+        queryForm={mockQueryParams}
+        disableDownloads={false}
+        onDownload={mockOnDownload}
+      />
+    );
+
+    cy.get('[data-cy="card-https://someportal.org/datasets/ds0001"]').should('be.visible');
+    cy.get('[data-cy="card-catalog-1"]').should('be.visible');
+
+    cy.contains('Subject-level datasets only').click();
+
+    cy.get('[data-cy="card-https://someportal.org/datasets/ds0001"]').should('be.visible');
+    cy.get('[data-cy="card-catalog-1"]').should('not.exist');
+  });
+
+  it('Only selects and downloads subject-level datasets when Select All is clicked with a mixed result', () => {
+    const mixedDatasetsResponse = {
+      errors: [],
+      nodes_response_status: 'success',
+      responses: [
+        { ...protectedResponse2.responses[0] },
+        {
+          ...protectedResponse2.responses[1],
+          dataset_uuid: 'catalog-1',
+          num_matching_subjects: null,
+          dataset_total_subjects: 150,
+        },
+      ],
+    };
+
+    cy.mount(
+      <ResultContainer
+        datasetsResponse={mixedDatasetsResponse}
+        assessmentOptions={[]}
+        diagnosisOptions={[]}
+        imagingModalitiesMetadata={imagingModalitiesMetadata}
+        queryForm={mockQueryParams}
+        disableDownloads={false}
+        onDownload={mockOnDownload}
+      />
+    );
+
+    cy.get('[data-cy="select-all-checkbox"] input').check();
+    cy.get('[data-cy="card-https://someportal.org/datasets/ds0001-checkbox"] input').should(
+      'be.checked'
+    );
+    cy.get('[data-cy="card-catalog-1-checkbox"] input').should('not.be.checked');
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,51 @@ import areFormStatesEqual, {
   sendSubjectsQuery,
 } from './utils/utils';
 
+const MOCK_INITIAL_RESULT = {
+  errors: [],
+  responses: [
+    {
+      dataset_uuid: 'mock-catalog-1',
+      dataset_name: 'Mock Catalog Dataset 1',
+      dataset_total_subjects: 150,
+      records_protected: false,
+      num_matching_subjects: null,
+      node_name: 'Mock Catalog Node',
+      image_modals: [],
+      available_pipelines: {},
+      access_type: 'public' as const,
+      access_email: null,
+      access_link: null,
+      authors: ['Mock Author 1'],
+      homepage: 'https://example.com/mock-catalog-1',
+      references_and_links: [],
+      keywords: ['mock', 'catalog'],
+      repository_url: 'https://example.com/mock-catalog-1',
+      access_instructions: null,
+    },
+    {
+      dataset_uuid: 'mock-subject-level-1',
+      dataset_name: 'Mock Subject-Level Dataset (Protected)',
+      dataset_total_subjects: 300,
+      records_protected: true,
+      num_matching_subjects: 50,
+      node_name: 'Mock Data Node',
+      image_modals: [],
+      available_pipelines: {},
+      access_type: 'restricted' as const,
+      access_email: 'test@example.com',
+      access_link: null,
+      authors: ['Mock Author 2'],
+      homepage: null,
+      references_and_links: [],
+      keywords: ['mock', 'protected', 'subject-level'],
+      repository_url: null,
+      access_instructions: 'Contact test@example.com',
+    },
+  ],
+  nodes_response_status: 'success',
+};
+
 function App() {
   // Screen is considered small if the width is less than 768px (according to tailwind docs)
   const [isScreenSizeSmall, setIsScreenSizeSmall] = useState<boolean>(
@@ -61,7 +106,7 @@ function App() {
 
   const [loading, setLoading] = useState<boolean>(false);
 
-  const [result, setResult] = useState<DatasetsResponse | null>(null);
+  const [result, setResult] = useState<DatasetsResponse | null>(MOCK_INITIAL_RESULT);
   const [resultStatus, setResultStatus] = useState<string>('success');
 
   const [minAge, setMinAge] = useState<string>('');
@@ -476,6 +521,7 @@ function App() {
 
     try {
       const data = await sendDatasetsQuery(datasetsRequestBody, IDToken);
+
       setResult(data);
       setResultStatus(data.nodes_response_status);
       setActiveQueryParams(datasetsRequestBody);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,51 +41,6 @@ import areFormStatesEqual, {
   sendSubjectsQuery,
 } from './utils/utils';
 
-const MOCK_INITIAL_RESULT = {
-  errors: [],
-  responses: [
-    {
-      dataset_uuid: 'mock-catalog-1',
-      dataset_name: 'Mock Catalog Dataset 1',
-      dataset_total_subjects: 150,
-      records_protected: false,
-      num_matching_subjects: null,
-      node_name: 'Mock Catalog Node',
-      image_modals: [],
-      available_pipelines: {},
-      access_type: 'public' as const,
-      access_email: null,
-      access_link: null,
-      authors: ['Mock Author 1'],
-      homepage: 'https://example.com/mock-catalog-1',
-      references_and_links: [],
-      keywords: ['mock', 'catalog'],
-      repository_url: 'https://example.com/mock-catalog-1',
-      access_instructions: null,
-    },
-    {
-      dataset_uuid: 'mock-subject-level-1',
-      dataset_name: 'Mock Subject-Level Dataset (Protected)',
-      dataset_total_subjects: 300,
-      records_protected: true,
-      num_matching_subjects: 50,
-      node_name: 'Mock Data Node',
-      image_modals: [],
-      available_pipelines: {},
-      access_type: 'restricted' as const,
-      access_email: 'test@example.com',
-      access_link: null,
-      authors: ['Mock Author 2'],
-      homepage: null,
-      references_and_links: [],
-      keywords: ['mock', 'protected', 'subject-level'],
-      repository_url: null,
-      access_instructions: 'Contact test@example.com',
-    },
-  ],
-  nodes_response_status: 'success',
-};
-
 function App() {
   // Screen is considered small if the width is less than 768px (according to tailwind docs)
   const [isScreenSizeSmall, setIsScreenSizeSmall] = useState<boolean>(
@@ -106,7 +61,7 @@ function App() {
 
   const [loading, setLoading] = useState<boolean>(false);
 
-  const [result, setResult] = useState<DatasetsResponse | null>(MOCK_INITIAL_RESULT);
+  const [result, setResult] = useState<DatasetsResponse | null>(null);
   const [resultStatus, setResultStatus] = useState<string>('success');
 
   const [minAge, setMinAge] = useState<string>('');

--- a/src/components/ResultCard/DatasetInfoColumn.tsx
+++ b/src/components/ResultCard/DatasetInfoColumn.tsx
@@ -12,6 +12,7 @@ interface DatasetInfoColumnProps {
   homepage: string | null;
   repositoryUrl: string | null;
   accessType: 'public' | 'registered' | 'restricted' | null;
+  isCatalog?: boolean;
 }
 
 function DatasetInfoColumn({
@@ -23,6 +24,7 @@ function DatasetInfoColumn({
   homepage,
   repositoryUrl,
   accessType,
+  isCatalog,
 }: DatasetInfoColumnProps) {
   return (
     <>
@@ -30,6 +32,7 @@ function DatasetInfoColumn({
         data-cy={`card-${datasetUuid}-checkbox`}
         checked={checked}
         onChange={() => onCheckboxChange(datasetUuid)}
+        disabled={isCatalog}
         sx={{ p: 0.5, alignSelf: 'center' }}
       />
       <Stack spacing={0.5} sx={{ minWidth: 0 }}>

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -45,10 +45,26 @@ const ResultCard = memo(
       available_pipelines: availablePipelines,
     } = dataset;
     const [isExpanded, setIsExpanded] = useState(false);
+    const isCatalog = numMatchingSubjects === null;
 
     return (
-      <Card data-cy={`card-${datasetUuid}`} sx={{ mb: 2 }}>
-        <ResultCardHeader nodeName={nodeName} recordsProtected={recordsProtected} />
+      <Card
+        data-cy={`card-${datasetUuid}`}
+        sx={{
+          mb: 2,
+          borderLeft: isCatalog ? 'none' : '4px solid',
+          borderLeftColor: 'primary.main',
+          transition: 'box-shadow 0.2s',
+          '&:hover': {
+            boxShadow: isCatalog ? 1 : 4,
+          },
+        }}
+      >
+        <ResultCardHeader
+          nodeName={nodeName}
+          recordsProtected={recordsProtected}
+          isCatalog={isCatalog}
+        />
 
         <CardContent>
           <div className="grid grid-cols-12 items-center gap-4">
@@ -62,6 +78,7 @@ const ResultCard = memo(
                 homepage={homepage}
                 repositoryUrl={repositoryUrl}
                 accessType={accessType}
+                isCatalog={isCatalog}
               />
             </div>
 

--- a/src/components/ResultCard/ResultCard.tsx
+++ b/src/components/ResultCard/ResultCard.tsx
@@ -48,18 +48,7 @@ const ResultCard = memo(
     const isCatalog = numMatchingSubjects === null;
 
     return (
-      <Card
-        data-cy={`card-${datasetUuid}`}
-        sx={{
-          mb: 2,
-          borderLeft: isCatalog ? 'none' : '4px solid',
-          borderLeftColor: 'primary.main',
-          transition: 'box-shadow 0.2s',
-          '&:hover': {
-            boxShadow: isCatalog ? 1 : 4,
-          },
-        }}
-      >
+      <Card data-cy={`card-${datasetUuid}`} sx={{ mb: 2 }}>
         <ResultCardHeader
           nodeName={nodeName}
           recordsProtected={recordsProtected}

--- a/src/components/ResultCard/ResultCardHeader.tsx
+++ b/src/components/ResultCard/ResultCardHeader.tsx
@@ -1,16 +1,19 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Tooltip } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import PersonIcon from '@mui/icons-material/Person';
 import NodeModeIcon from './NodeModeIcon';
 
 interface ResultCardHeaderProps {
   nodeName: string;
   recordsProtected: boolean;
+  isCatalog?: boolean;
 }
 
-function ResultCardHeader({ nodeName, recordsProtected }: ResultCardHeaderProps) {
+function ResultCardHeader({ nodeName, recordsProtected, isCatalog }: ResultCardHeaderProps) {
   return (
     <Box
       sx={{
-        bgcolor: 'grey.100',
+        bgcolor: isCatalog ? 'rgba(211, 47, 47, 0.04)' : 'rgba(46, 125, 50, 0.04)',
         px: 2,
         py: 1,
         display: 'flex',
@@ -24,6 +27,16 @@ function ResultCardHeader({ nodeName, recordsProtected }: ResultCardHeaderProps)
         {nodeName} node
       </Typography>
       <NodeModeIcon recordsProtected={recordsProtected} />
+      {isCatalog !== undefined && (
+        <Tooltip
+          title={isCatalog ? 'Catalog-Level Dataset (No Subject Data)' : 'Subject-Level Dataset'}
+          placement="top"
+        >
+          <div className="ml-1 flex items-center gap-1">
+            {isCatalog ? <MenuBookIcon fontSize="small" /> : <PersonIcon fontSize="small" />}
+          </div>
+        </Tooltip>
+      )}
     </Box>
   );
 }

--- a/src/components/ResultCard/ResultCardHeader.tsx
+++ b/src/components/ResultCard/ResultCardHeader.tsx
@@ -6,7 +6,7 @@ import NodeModeIcon from './NodeModeIcon';
 interface ResultCardHeaderProps {
   nodeName: string;
   recordsProtected: boolean;
-  isCatalog?: boolean;
+  isCatalog: boolean;
 }
 
 function ResultCardHeader({ nodeName, recordsProtected, isCatalog }: ResultCardHeaderProps) {
@@ -27,16 +27,14 @@ function ResultCardHeader({ nodeName, recordsProtected, isCatalog }: ResultCardH
         {nodeName} node
       </Typography>
       <NodeModeIcon recordsProtected={recordsProtected} />
-      {isCatalog !== undefined && (
-        <Tooltip
-          title={isCatalog ? 'Catalog-Level Dataset (No Subject Data)' : 'Subject-Level Dataset'}
-          placement="top"
-        >
-          <div className="ml-1 flex items-center gap-1">
-            {isCatalog ? <MenuBookIcon fontSize="small" /> : <PersonIcon fontSize="small" />}
-          </div>
-        </Tooltip>
-      )}
+      <Tooltip
+        title={isCatalog ? 'Catalog-Level Dataset (No Subject Data)' : 'Subject-Level Dataset'}
+        placement="top"
+      >
+        <div className="ml-1 flex items-center gap-1">
+          {isCatalog ? <MenuBookIcon fontSize="small" /> : <PersonIcon fontSize="small" />}
+        </div>
+      </Tooltip>
     </Box>
   );
 }

--- a/src/components/ResultCard/ResultCardHeader.tsx
+++ b/src/components/ResultCard/ResultCardHeader.tsx
@@ -13,7 +13,7 @@ function ResultCardHeader({ nodeName, recordsProtected, isCatalog }: ResultCardH
   return (
     <Box
       sx={{
-        bgcolor: isCatalog ? 'rgba(211, 47, 47, 0.04)' : 'rgba(46, 125, 50, 0.04)',
+        bgcolor: 'grey.100',
         px: 2,
         py: 1,
         display: 'flex',

--- a/src/components/ResultCard/SubjectCountColumn.tsx
+++ b/src/components/ResultCard/SubjectCountColumn.tsx
@@ -16,15 +16,31 @@ function SubjectCountColumn({
       <Typography variant="body2" fontWeight="bold">
         Matching subjects:
       </Typography>
-      <Typography variant="h6">
+      <div className="mt-1">
         {isCatalog ? (
-          <>
-            <span className="text-base italic text-gray-500">Unknown</span> / {datasetTotalSubjects}
-          </>
+          <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+            Unknown / {datasetTotalSubjects}
+          </Typography>
         ) : (
-          `${numMatchingSubjects} / ${datasetTotalSubjects}`
+          <div className="flex items-baseline gap-1.5">
+            <Typography
+              variant="h4"
+              component="span"
+              sx={{ color: '#0891b2', fontWeight: 900, lineHeight: 1, letterSpacing: '-0.02em' }}
+            >
+              {numMatchingSubjects}
+            </Typography>
+            <Typography
+              variant="subtitle1"
+              component="span"
+              color="text.secondary"
+              sx={{ fontWeight: 'bold' }}
+            >
+              / {datasetTotalSubjects}
+            </Typography>
+          </div>
         )}
-      </Typography>
+      </div>
     </>
   );
 }

--- a/src/components/ResultCard/SubjectCountColumn.tsx
+++ b/src/components/ResultCard/SubjectCountColumn.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@mui/material';
 
 interface SubjectCountColumnProps {
-  numMatchingSubjects: number;
+  numMatchingSubjects: number | null;
   datasetTotalSubjects: number;
 }
 
@@ -9,13 +9,21 @@ function SubjectCountColumn({
   numMatchingSubjects,
   datasetTotalSubjects,
 }: SubjectCountColumnProps) {
+  const isCatalog = numMatchingSubjects === null;
+
   return (
     <>
       <Typography variant="body2" fontWeight="bold">
         Matching subjects:
       </Typography>
       <Typography variant="h6">
-        {numMatchingSubjects} / {datasetTotalSubjects}
+        {isCatalog ? (
+          <>
+            <span className="text-base italic text-gray-500">Unknown</span> / {datasetTotalSubjects}
+          </>
+        ) : (
+          `${numMatchingSubjects} / ${datasetTotalSubjects}`
+        )}
       </Typography>
     </>
   );

--- a/src/components/ResultContainer.tsx
+++ b/src/components/ResultContainer.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { FormControlLabel, Checkbox, Typography } from '@mui/material';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { FormControlLabel, Checkbox, Typography, Switch } from '@mui/material';
 import ResultCard from './ResultCard/ResultCard';
 import {
   DatasetsResponse,
@@ -33,20 +33,35 @@ function ResultContainer({
   onDownload: DownloadHandler;
 }) {
   const [download, setDownload] = useState<string[]>([]);
-  const selectAll: boolean = datasetsResponse
-    ? datasetsResponse.responses.length === download.length &&
-      datasetsResponse.responses.every((r) => download.includes(r.dataset_uuid))
-    : false;
+  const [subjectLevelOnly, setSubjectLevelOnly] = useState<boolean>(false);
+
+  const displayedDatasets = useMemo(() => {
+    if (!datasetsResponse) return [];
+    if (subjectLevelOnly) {
+      return datasetsResponse.responses.filter((d) => d.num_matching_subjects !== null);
+    }
+    return datasetsResponse.responses;
+  }, [datasetsResponse, subjectLevelOnly]);
+
+  const downloadableDatasets = useMemo(() => {
+    if (!datasetsResponse) return [];
+    return datasetsResponse.responses.filter((d) => d.num_matching_subjects !== null);
+  }, [datasetsResponse]);
+
+  const selectAll: boolean =
+    downloadableDatasets.length > 0 &&
+    downloadableDatasets.length === download.length &&
+    downloadableDatasets.every((r) => download.includes(r.dataset_uuid));
 
   let numOfMatchedDatasets = 0;
   let numOfMatchedSubjects = 0;
-  if (datasetsResponse) {
-    datasetsResponse.responses.forEach((item) => {
-      numOfMatchedDatasets += 1;
-      numOfMatchedSubjects += item.num_matching_subjects;
-    });
-  }
-  const summaryStats = `Summary stats: ${numOfMatchedDatasets} datasets, ${numOfMatchedSubjects} subjects`;
+  let totalSubjects = 0;
+  displayedDatasets.forEach((item) => {
+    numOfMatchedDatasets += 1;
+    numOfMatchedSubjects += item.num_matching_subjects || 0;
+    totalSubjects += item.dataset_total_subjects || 0;
+  });
+  const summaryStats = `Summary stats: ${numOfMatchedDatasets} datasets, ${numOfMatchedSubjects} matching subjects, ${totalSubjects} total subjects`;
   const [loading, setLoading] = useState<boolean>(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
 
@@ -69,10 +84,8 @@ function ResultContainer({
   }, []);
 
   function handleSelectAll(checked: boolean) {
-    if (datasetsResponse) {
-      const uuids = datasetsResponse.responses.map((item) => item.dataset_uuid);
-      setDownload(checked ? uuids : []);
-    }
+    const uuids = downloadableDatasets.map((item) => item.dataset_uuid);
+    setDownload(checked ? uuids : []);
   }
 
   useEffect(() => {
@@ -335,8 +348,8 @@ function ResultContainer({
 
     return (
       <>
-        <div className="flex flex-row items-baseline justify-between">
-          <div>
+        <div className="mb-4 flex flex-row items-baseline justify-between">
+          <div className="flex flex-row items-center gap-4">
             <FormControlLabel
               data-cy="select-all-checkbox"
               label="Select all datasets"
@@ -344,6 +357,16 @@ function ResultContainer({
                 <Checkbox
                   onChange={(event) => handleSelectAll(event.target.checked)}
                   checked={selectAll}
+                />
+              }
+            />
+            <FormControlLabel
+              label="Subject-level datasets only"
+              control={
+                <Switch
+                  checked={subjectLevelOnly}
+                  onChange={(e) => setSubjectLevelOnly(e.target.checked)}
+                  color="primary"
                 />
               }
             />
@@ -355,7 +378,7 @@ function ResultContainer({
           </div>
         </div>
         <div className="h-[65vh] space-y-1 overflow-auto">
-          {datasetsResponse.responses.map((item) => (
+          {displayedDatasets.map((item) => (
             <ResultCard
               key={item.dataset_uuid}
               dataset={item}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -112,7 +112,7 @@ export interface DatasetsResult {
   access_link: string | null;
   dataset_total_subjects: number;
   records_protected: boolean;
-  num_matching_subjects: number;
+  num_matching_subjects: number | null;
   image_modals: string[];
   available_pipelines: Pipelines;
 }


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #790 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added support for catalog-mode datasets by allowing `num_matching_subjects` to be null
- Implemented a toggle switch to optionally filter and display only subject-level datasets
- Redesign catalog dataset cards with distinct icons, tooltips, and muted "Unknown" subject counts
- Updated "Select All" functionality to exclusively target and allow downloading of subject-level datasets
- Updated summary statistics to display both matching and total subject counts across datasets
- Updated Cypress component tests to verify the new catalog-mode rendering, filtering, and selection logic

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Differentiate catalog-level datasets from subject-level datasets in the UI and selection logic while updating summary statistics to handle missing subject counts.

New Features:
- Add support for catalog-level datasets with no subject-level records, including type changes to allow null matching subject counts.
- Introduce a toggle to show only subject-level datasets and update dataset selection to apply only to datasets with subject data.
- Visually distinguish catalog-level vs subject-level datasets in result cards with header styling and icons, and disable selection for catalog-only entries.
- Add an initial mock datasets result in the app state to populate the results view without an executed query.

Enhancements:
- Update summary statistics to display matching and total subject counts based on the currently displayed datasets and to account for catalog-only datasets.

## Summary by Sourcery

Differentiate catalog-level from subject-level datasets in the results view, updating selection behavior and summary statistics to handle datasets without subject-level records.

New Features:
- Support catalog-level datasets by allowing null matching-subject counts and rendering them distinctly in result cards, including specialized icons and subject count display.
- Add a toggle to filter the results view to subject-level datasets only.
- Restrict dataset selection and bulk "Select all" downloads to subject-level datasets with available subject data.

Enhancements:
- Revise summary statistics and subject count presentation to show matching vs total subjects based on the currently displayed datasets and to account for catalog-only entries.

Tests:
- Extend Cypress component tests for ResultContainer and ResultCard to cover catalog dataset rendering, filtering, and subject-level-only selection behavior.