### PR TITLE
[ENH] Enable selecting multiple options for AND queries

### DIFF
--- a/cypress/component/CategoricalField.cy.tsx
+++ b/cypress/component/CategoricalField.cy.tsx
@@ -70,4 +70,58 @@ describe('CategoricalField', () => {
       label: 'Option 1',
     });
   });
+  it('Renders option checkboxes and stays open when multiple selection is enabled', () => {
+    cy.mount(
+      <CategoricalField
+        label={props.label}
+        options={props.options}
+        onFieldChange={props.onFieldChange}
+        inputValue={[]}
+        multiple={true}
+      />
+    );
+    cy.get('[data-cy="Categorical Field-categorical-field"]').click();
+    cy.get('.MuiAutocomplete-popper').should('be.visible');
+    cy.get('.MuiAutocomplete-option').should('have.length', 3);
+    cy.get('.MuiAutocomplete-option .MuiCheckbox-root').should('have.length', 3);
+
+    cy.contains('.MuiAutocomplete-option', 'Option 1').click();
+    cy.get('.MuiAutocomplete-popper').should('be.visible');
+  });
+  it('Fires onFieldChange event handler with an array payload when multiple selection is enabled', () => {
+    const onFieldChangeSpy = cy.spy().as('onFieldChangeSpy');
+    cy.mount(
+      <CategoricalField
+        label={props.label}
+        options={props.options}
+        onFieldChange={onFieldChangeSpy}
+        inputValue={[]}
+        multiple={true}
+      />
+    );
+    cy.get('[data-cy="Categorical Field-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'Option 1').click();
+    cy.get('@onFieldChangeSpy').should('have.been.calledWith', 'Categorical Field', [
+      { id: '1', label: 'Option 1' },
+    ]);
+  });
+  it('Supports custom renderGroup prop for grouped options', () => {
+    cy.mount(
+      <CategoricalField
+        label={props.label}
+        options={props.options}
+        onFieldChange={props.onFieldChange}
+        inputValue={props.inputValue}
+        renderGroup={(params) => (
+          <li key={params.key}>
+            <div data-cy="custom-group-header">{params.group}</div>
+            <ul>{params.children}</ul>
+          </li>
+        )}
+        groupBy={() => 'Group 1'}
+      />
+    );
+    cy.get('[data-cy="Categorical Field-categorical-field"]').click();
+    cy.get('[data-cy="custom-group-header"]').should('contain', 'Group 1');
+  });
 });

--- a/cypress/component/CollapsiblePipelineGroup.cy.tsx
+++ b/cypress/component/CollapsiblePipelineGroup.cy.tsx
@@ -1,0 +1,81 @@
+import CollapsiblePipelineGroup from '../../src/components/CollapsiblePipelineGroup';
+
+describe('CollapsiblePipelineGroup', () => {
+  it('should render the group label and unchecked checkbox when pipeline is not selected', () => {
+    const onTogglePipelineSpy = cy.spy().as('onTogglePipelineSpy');
+    cy.mount(
+      <ul>
+        <CollapsiblePipelineGroup
+          groupKey="np:fmriprep"
+          groupLabel="fmriprep"
+          selectedPipelines={[]}
+          selectedVersions={[]}
+          onTogglePipeline={onTogglePipelineSpy}
+        >
+          <li key="v1">fmriprep 0.2.3</li>
+        </CollapsiblePipelineGroup>
+      </ul>
+    );
+
+    cy.contains('fmriprep').should('be.visible');
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"] input').should('not.be.checked');
+  });
+
+  it('should render checkbox as checked when pipeline is selected without specific versions', () => {
+    const onTogglePipelineSpy = cy.spy().as('onTogglePipelineSpy');
+    cy.mount(
+      <ul>
+        <CollapsiblePipelineGroup
+          groupKey="np:fmriprep"
+          groupLabel="fmriprep"
+          selectedPipelines={[{ id: 'np:fmriprep', label: 'fmriprep' }]}
+          selectedVersions={[]}
+          onTogglePipeline={onTogglePipelineSpy}
+        >
+          <li key="v1">fmriprep 0.2.3</li>
+        </CollapsiblePipelineGroup>
+      </ul>
+    );
+
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"] input').should('be.checked');
+  });
+
+  it('should render checkbox as unchecked when specific versions are selected', () => {
+    const onTogglePipelineSpy = cy.spy().as('onTogglePipelineSpy');
+    cy.mount(
+      <ul>
+        <CollapsiblePipelineGroup
+          groupKey="np:fmriprep"
+          groupLabel="fmriprep"
+          selectedPipelines={[{ id: 'np:fmriprep', label: 'fmriprep' }]}
+          selectedVersions={[{ id: 'np:fmriprep::0.2.3', label: 'fmriprep 0.2.3' }]}
+          onTogglePipeline={onTogglePipelineSpy}
+        >
+          <li key="v1">fmriprep 0.2.3</li>
+        </CollapsiblePipelineGroup>
+      </ul>
+    );
+
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"] input').should('not.be.checked');
+  });
+
+  it('should fire onTogglePipeline event handler when clicking the group header checkbox', () => {
+    const onTogglePipelineSpy = cy.spy().as('onTogglePipelineSpy');
+    cy.mount(
+      <ul>
+        <CollapsiblePipelineGroup
+          groupKey="np:fmriprep"
+          groupLabel="fmriprep"
+          selectedPipelines={[]}
+          selectedVersions={[]}
+          onTogglePipeline={onTogglePipelineSpy}
+        >
+          <li key="v1">fmriprep 0.2.3</li>
+        </CollapsiblePipelineGroup>
+      </ul>
+    );
+
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
+    cy.get('@onTogglePipelineSpy').should('have.been.calledWith', 'np:fmriprep', 'fmriprep');
+  });
+});

--- a/cypress/component/QueryForm.cy.tsx
+++ b/cypress/component/QueryForm.cy.tsx
@@ -159,10 +159,12 @@ describe('QueryForm', () => {
     );
 
     cy.get('[data-cy="Diagnosis-categorical-field"]').type('Some{downarrow}{enter}');
-    cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Diagnosis', {
-      id: 'https://someurl/',
-      label: 'Some Diagnosis',
-    });
+    cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Diagnosis', [
+      {
+        id: 'https://someurl/',
+        label: 'Some Diagnosis',
+      },
+    ]);
   });
   it('Fires updateContinuousQueryParams event handler with the appropriate payload when a continuous field is selected', () => {
     const updateContinuousQueryParamsSpy = cy.spy().as('updateContinuousQueryParamsSpy');

--- a/cypress/component/QueryForm.cy.tsx
+++ b/cypress/component/QueryForm.cy.tsx
@@ -97,8 +97,7 @@ describe('QueryForm', () => {
     );
     cy.get('[data-cy="Assessment tool-categorical-field"]').should('be.visible');
     cy.get('[data-cy="Imaging modality-categorical-field"]').should('be.visible');
-    cy.get('[data-cy="Pipeline name-categorical-field"]').should('be.visible');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('be.visible');
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('be.visible');
     cy.get('[data-cy="submit-query-button"]').should('be.visible');
     cy.get('[data-cy="how-to-get-data-dialog-button"]').should('be.visible');
   });

--- a/cypress/component/QueryForm.cy.tsx
+++ b/cypress/component/QueryForm.cy.tsx
@@ -97,7 +97,7 @@ describe('QueryForm', () => {
     );
     cy.get('[data-cy="Assessment tool-categorical-field"]').should('be.visible');
     cy.get('[data-cy="Imaging modality-categorical-field"]').should('be.visible');
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('be.visible');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should('be.visible');
     cy.get('[data-cy="submit-query-button"]').should('be.visible');
     cy.get('[data-cy="how-to-get-data-dialog-button"]').should('be.visible');
   });
@@ -250,7 +250,7 @@ describe('QueryForm', () => {
       />
     );
 
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline name', [
       { id: 'np:fmriprep', label: 'fmriprep' },
@@ -286,7 +286,7 @@ describe('QueryForm', () => {
       />
     );
 
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
     cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline name', [
       { id: 'np:fmriprep', label: 'fmriprep' },

--- a/cypress/component/QueryForm.cy.tsx
+++ b/cypress/component/QueryForm.cy.tsx
@@ -223,4 +223,78 @@ describe('QueryForm', () => {
     cy.get('[data-cy="submit-query-button"]').click();
     cy.get('@onSubmitQuerySpy').should('have.been.called');
   });
+  it('Fires updateCategoricalQueryParams event handler when selecting a pipeline version in the Pipeline field', () => {
+    const updateCategoricalQueryParamsSpy = cy.spy().as('updateCategoricalQueryParamsSpy');
+    cy.mount(
+      <QueryForm
+        availableNodes={defaultProps.availableNodes}
+        diagnosisOptions={defaultProps.diagnosisOptions}
+        assessmentOptions={defaultProps.assessmentOptions}
+        imagingModalityOptions={defaultProps.imagingModalityOptions}
+        selectedNode={defaultProps.selectedNode}
+        minAge={defaultProps.minAge}
+        maxAge={defaultProps.maxAge}
+        sex={defaultProps.sex}
+        diagnosis={defaultProps.diagnosis}
+        minNumImagingSessions={defaultProps.minNumImagingSessions}
+        minNumPhenotypicSessions={defaultProps.minNumPhenotypicSessions}
+        assessmentTool={defaultProps.assessmentTool}
+        imagingModality={defaultProps.imagingModality}
+        pipelineVersion={defaultProps.pipelineVersion}
+        pipelineName={defaultProps.pipelineName}
+        pipelines={defaultProps.pipelines}
+        updateCategoricalQueryParams={updateCategoricalQueryParamsSpy}
+        updateContinuousQueryParams={defaultProps.updateContinuousQueryParams}
+        loading={defaultProps.loading}
+        onSubmitQuery={defaultProps.onSubmitQuery}
+      />
+    );
+
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
+    cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline name', [
+      { id: 'np:fmriprep', label: 'fmriprep' },
+    ]);
+    cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline version', [
+      { id: 'np:fmriprep::0.2.3', label: 'fmriprep 0.2.3' },
+    ]);
+  });
+  it('Fires updateCategoricalQueryParams event handler when clicking the pipeline group header checkbox in the Pipeline field', () => {
+    const updateCategoricalQueryParamsSpy = cy.spy().as('updateCategoricalQueryParamsSpy');
+    cy.mount(
+      <QueryForm
+        availableNodes={defaultProps.availableNodes}
+        diagnosisOptions={defaultProps.diagnosisOptions}
+        assessmentOptions={defaultProps.assessmentOptions}
+        imagingModalityOptions={defaultProps.imagingModalityOptions}
+        selectedNode={defaultProps.selectedNode}
+        minAge={defaultProps.minAge}
+        maxAge={defaultProps.maxAge}
+        sex={defaultProps.sex}
+        diagnosis={defaultProps.diagnosis}
+        minNumImagingSessions={defaultProps.minNumImagingSessions}
+        minNumPhenotypicSessions={defaultProps.minNumPhenotypicSessions}
+        assessmentTool={defaultProps.assessmentTool}
+        imagingModality={defaultProps.imagingModality}
+        pipelineVersion={defaultProps.pipelineVersion}
+        pipelineName={defaultProps.pipelineName}
+        pipelines={defaultProps.pipelines}
+        updateCategoricalQueryParams={updateCategoricalQueryParamsSpy}
+        updateContinuousQueryParams={defaultProps.updateContinuousQueryParams}
+        loading={defaultProps.loading}
+        onSubmitQuery={defaultProps.onSubmitQuery}
+      />
+    );
+
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
+    cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline name', [
+      { id: 'np:fmriprep', label: 'fmriprep' },
+    ]);
+    cy.get('@updateCategoricalQueryParamsSpy').should(
+      'have.been.calledWith',
+      'Pipeline version',
+      null
+    );
+  });
 });

--- a/cypress/component/QueryForm.cy.tsx
+++ b/cypress/component/QueryForm.cy.tsx
@@ -251,6 +251,7 @@ describe('QueryForm', () => {
     );
 
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('@updateCategoricalQueryParamsSpy').should('have.been.calledWith', 'Pipeline name', [
       { id: 'np:fmriprep', label: 'fmriprep' },

--- a/cypress/e2e/APIRequests.cy.ts
+++ b/cypress/e2e/APIRequests.cy.ts
@@ -85,6 +85,7 @@ describe('Successful API attribute responses', () => {
   it('Loads pipeline versions correctly if all node responses are successful', () => {
     cy.get('[data-cy="close-auth-dialog-button"]').click();
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 23.1.3').click();
   });
   it('Empty diagnosis response makes info toast appear', () => {
@@ -461,6 +462,7 @@ describe('Successful API query requests', () => {
     cy.get('[data-cy="Minimum number of imaging sessions-continuous-field"]').type('2');
     cy.get('[data-cy="Minimum number of phenotypic sessions-continuous-field"]').type('3');
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
       'contain',

--- a/cypress/e2e/APIRequests.cy.ts
+++ b/cypress/e2e/APIRequests.cy.ts
@@ -440,6 +440,13 @@ describe('Successful API query requests', () => {
       },
       pipelineOptions
     ).as('getPipelineOptions');
+    cy.intercept(
+      {
+        method: 'GET',
+        url: 'pipelines/np:fmriprep/versions',
+      },
+      pipelineVersionOptions
+    ).as('getPipelineVersionsOptions');
     cy.visit('/');
     cy.wait([
       '@getNodes',
@@ -460,9 +467,12 @@ describe('Successful API query requests', () => {
     cy.get('[data-cy="Minimum number of phenotypic sessions-continuous-field"]').type('3');
     // Assert that pipeline version doesn't sneak into the query if pipeline name is cleared
     cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
+    cy.wait('@getPipelineVersionsOptions');
     cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
-    cy.get('[data-cy="Pipeline name-categorical-field"]').clear();
+    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
+    cy.get('[data-cy="Pipeline name-categorical-field"]')
+      .find('.MuiAutocomplete-clearIndicator')
+      .click({ force: true });
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
     cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
     cy.get('[data-cy="submit-query-button"]').click();
@@ -471,7 +481,7 @@ describe('Successful API query requests', () => {
       expect(interception.request.body).to.have.property('max_age', 30);
       expect(interception.request.body).to.have.property('min_num_imaging_sessions', 2);
       expect(interception.request.body).to.have.property('min_num_phenotypic_sessions', 3);
-      expect(interception.request.body).to.not.have.property('pipeline_version');
+      expect(interception.request.body).to.not.have.property('pipeline');
     });
   });
 });
@@ -525,10 +535,7 @@ describe('Regression Tests', () => {
     cy.get('[data-cy="close-auth-dialog-button"]').click();
 
     cy.get('[data-cy="Diagnosis-categorical-field"]').type('parkin{downarrow}{enter}');
-    cy.get('[data-cy="Diagnosis-categorical-field"] input').should(
-      'have.value',
-      "Parkinson's disease"
-    );
+    cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
   });
 });
 

--- a/cypress/e2e/APIRequests.cy.ts
+++ b/cypress/e2e/APIRequests.cy.ts
@@ -84,7 +84,7 @@ describe('Successful API attribute responses', () => {
   });
   it('Loads pipeline versions correctly if all node responses are successful', () => {
     cy.get('[data-cy="close-auth-dialog-button"]').click();
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 23.1.3').click();
   });
   it('Empty diagnosis response makes info toast appear', () => {
@@ -460,13 +460,19 @@ describe('Successful API query requests', () => {
     cy.get('[data-cy="Maximum age-continuous-field"]').type('30');
     cy.get('[data-cy="Minimum number of imaging sessions-continuous-field"]').type('2');
     cy.get('[data-cy="Minimum number of phenotypic sessions-continuous-field"]').type('3');
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
-    cy.get('[data-cy="Pipeline-categorical-field"]')
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'contain',
+      'fmriprep 0.2.3'
+    );
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]')
       .find('.MuiAutocomplete-clearIndicator')
       .click({ force: true });
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'not.contain',
+      'fmriprep 0.2.3'
+    );
     cy.get('[data-cy="submit-query-button"]').click();
     cy.wait('@call').then((interception) => {
       expect(interception.request.body).to.have.property('min_age', 10);

--- a/cypress/e2e/APIRequests.cy.ts
+++ b/cypress/e2e/APIRequests.cy.ts
@@ -84,9 +84,8 @@ describe('Successful API attribute responses', () => {
   });
   it('Loads pipeline versions correctly if all node responses are successful', () => {
     cy.get('[data-cy="close-auth-dialog-button"]').click();
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').type('23.1.3{downarrow}{enter}');
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 23.1.3').click();
   });
   it('Empty diagnosis response makes info toast appear', () => {
     cy.intercept(
@@ -174,9 +173,8 @@ describe('Successful API attribute responses', () => {
       emptyPipelineVersionOptions
     ).as('getPipelineVersionsOptions');
     cy.visit('/');
-    cy.get('[data-cy="close-auth-dialog-button"]').click();
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
     cy.wait('@getPipelineVersionsOptions');
+    cy.get('[data-cy="close-auth-dialog-button"]').click();
     cy.get("[data-cy='notification-button']").should('exist');
     cy.get("[data-cy='notification-button']").click({ force: true });
     cy.get('.MuiListItem-root')
@@ -263,8 +261,6 @@ describe('Partially successful API attribute responses', () => {
   });
   it('Shows warning for node that failed Pipeline version option request', () => {
     cy.get('[data-cy="close-auth-dialog-button"]').click();
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
     cy.get("[data-cy='notification-button']").should('exist');
     cy.get("[data-cy='notification-button']").click({ force: true });
     cy.get('.MuiList-root').should('contain', 'NoPipelineVersionNode');
@@ -390,10 +386,9 @@ describe('Failed API attribute responses continued', () => {
       '@getDiagnosisOptions',
       '@getAssessmentToolOptions',
       '@getPipelineOptions',
+      '@getPipelineVersionsOptions',
     ]);
     cy.get('[data-cy="close-auth-dialog-button"]').click();
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
     cy.get('.notistack-SnackbarContainer')
       .find('.notistack-MuiContent-error')
       .should('contain', 'versions');
@@ -465,16 +460,13 @@ describe('Successful API query requests', () => {
     cy.get('[data-cy="Maximum age-continuous-field"]').type('30');
     cy.get('[data-cy="Minimum number of imaging sessions-continuous-field"]').type('2');
     cy.get('[data-cy="Minimum number of phenotypic sessions-continuous-field"]').type('3');
-    // Assert that pipeline version doesn't sneak into the query if pipeline name is cleared
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
-    cy.get('[data-cy="Pipeline name-categorical-field"]')
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline-categorical-field"]')
       .find('.MuiAutocomplete-clearIndicator')
       .click({ force: true });
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
     cy.get('[data-cy="submit-query-button"]').click();
     cy.wait('@call').then((interception) => {
       expect(interception.request.body).to.have.property('min_age', 10);

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -68,6 +68,7 @@ describe('App', () => {
   });
   it('Allows selecting a pipeline option in the Pipeline field', () => {
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
       'contain',
@@ -76,6 +77,7 @@ describe('App', () => {
   });
   it('Should clear selected pipeline options when the clear button is clicked', () => {
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
       'contain',
@@ -91,6 +93,7 @@ describe('App', () => {
   });
   it('should clear specific pipeline versions when clicking the pipeline group header checkbox', () => {
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
+    cy.contains('fmriprep').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
       'contain',

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -57,10 +57,7 @@ describe('App', () => {
   it('Displays the diagnosis options it retrieves from a node API', () => {
     cy.get('[data-cy="Diagnosis-categorical-field"] input').should('not.be.disabled');
     cy.get('[data-cy="Diagnosis-categorical-field"]').type('parkin{downarrow}{enter}');
-    cy.get('[data-cy="Diagnosis-categorical-field"] input').should(
-      'have.value',
-      "Parkinson's disease"
-    );
+    cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
   });
   it('Enables the pipeline version field once a pipeline name is selected', () => {
     cy.intercept(
@@ -75,7 +72,7 @@ describe('App', () => {
     cy.wait('@getPipelineVersionsOptions');
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
     cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
+    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
   });
   it('Should disable and clear the pipeline version field when the pipeline name field is cleared', () => {
     cy.intercept(
@@ -90,8 +87,10 @@ describe('App', () => {
     cy.wait('@getPipelineVersionsOptions');
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
     cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('have.value', '0.2.3');
-    cy.get('[data-cy="Pipeline name-categorical-field"]').clear();
+    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
+    cy.get('[data-cy="Pipeline name-categorical-field"]')
+      .find('.MuiAutocomplete-clearIndicator')
+      .click({ force: true });
     cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
     cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
   });

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -67,26 +67,41 @@ describe('App', () => {
     cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
   });
   it('Allows selecting a pipeline option in the Pipeline field', () => {
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'contain',
+      'fmriprep 0.2.3'
+    );
   });
   it('Should clear selected pipeline options when the clear button is clicked', () => {
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
-    cy.get('[data-cy="Pipeline-categorical-field"]')
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'contain',
+      'fmriprep 0.2.3'
+    );
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]')
       .find('.MuiAutocomplete-clearIndicator')
       .click({ force: true });
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'not.contain',
+      'fmriprep 0.2.3'
+    );
   });
   it('should clear specific pipeline versions when clicking the pipeline group header checkbox', () => {
-    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').click();
     cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'contain',
+      'fmriprep 0.2.3'
+    );
     cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep');
-    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should('contain', 'fmriprep');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'not.contain',
+      'fmriprep 0.2.3'
+    );
   });
   it('should toggle the filter form visibility when clicking the button', () => {
     cy.viewport(800, 600); // Mobile/tablet viewport

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -97,7 +97,10 @@ describe('App', () => {
       'fmriprep 0.2.3'
     );
     cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
-    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should('contain', 'fmriprep');
+    cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
+      'contain',
+      'fmriprep any version'
+    );
     cy.get('[data-cy="Pipeline name and version-categorical-field"]').should(
       'not.contain',
       'fmriprep 0.2.3'

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -28,6 +28,13 @@ describe('App', () => {
       },
       pipelineOptions
     ).as('getPipelineOptions');
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/pipelines/np:fmriprep/versions',
+      },
+      pipelineVersionOptions
+    ).as('getPipelineVersionsOptions');
     cy.visit('/');
     cy.wait(['@getNodes', '@getDiagnosisOptions', '@getPipelineOptions']);
 
@@ -59,40 +66,19 @@ describe('App', () => {
     cy.get('[data-cy="Diagnosis-categorical-field"]').type('parkin{downarrow}{enter}');
     cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
   });
-  it('Enables the pipeline version field once a pipeline name is selected', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/pipelines/np:fmriprep/versions',
-      },
-      pipelineVersionOptions
-    ).as('getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
+  it('Allows selecting a pipeline option in the Pipeline field', () => {
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
   });
-  it('Should disable and clear the pipeline version field when the pipeline name field is cleared', () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/pipelines/np:fmriprep/versions',
-      },
-      pipelineVersionOptions
-    ).as('getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
-    cy.get('[data-cy="Pipeline name-categorical-field"]').type('fmri{downarrow}{enter}');
-    cy.wait('@getPipelineVersionsOptions');
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('not.be.disabled');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').type('0.2.3{downarrow}{enter}');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('contain', '0.2.3');
-    cy.get('[data-cy="Pipeline name-categorical-field"]')
+  it('Should clear selected pipeline options when the clear button is clicked', () => {
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="Pipeline-categorical-field"]')
       .find('.MuiAutocomplete-clearIndicator')
       .click({ force: true });
-    cy.get('[data-cy="Pipeline version-categorical-field"] input').should('be.disabled');
-    cy.get('[data-cy="Pipeline version-categorical-field"]').should('have.value', '');
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
   });
   it('should toggle the filter form visibility when clicking the button', () => {
     cy.viewport(800, 600); // Mobile/tablet viewport
@@ -128,7 +114,9 @@ describe('App', () => {
       'OpenNeur{downarrow}{enter}'
     );
     cy.get('[data-cy="Neurobagel graph-categorical-field"] input').type('Quebec{downarrow}{enter}');
-    cy.get('.MuiAutocomplete-clearIndicator').click();
+    cy.get('[data-cy="Neurobagel graph-categorical-field"]')
+      .find('.MuiAutocomplete-clearIndicator')
+      .click({ force: true });
     cy.get('[data-cy="Neurobagel graph-categorical-field"]')
       .should('not.contain', 'Quebec')
       .and('not.contain', 'OpenNeuro');

--- a/cypress/e2e/Form.cy.ts
+++ b/cypress/e2e/Form.cy.ts
@@ -80,6 +80,14 @@ describe('App', () => {
       .click({ force: true });
     cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
   });
+  it('should clear specific pipeline versions when clicking the pipeline group header checkbox', () => {
+    cy.get('[data-cy="Pipeline-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', 'fmriprep 0.2.3').click();
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep 0.2.3');
+    cy.get('[data-cy="pipeline-group-np:fmriprep-checkbox"]').click({ force: true });
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('contain', 'fmriprep');
+    cy.get('[data-cy="Pipeline-categorical-field"]').should('not.contain', 'fmriprep 0.2.3');
+  });
   it('should toggle the filter form visibility when clicking the button', () => {
     cy.viewport(800, 600); // Mobile/tablet viewport
     cy.get('[data-cy="filter-toggle-button"]').should('be.visible');

--- a/cypress/e2e/UndoQueryFormChanges.cy.ts
+++ b/cypress/e2e/UndoQueryFormChanges.cy.ts
@@ -44,17 +44,14 @@ describe('Undo cohort changes', () => {
     cy.get('[data-cy="download-results-button"]').should('not.be.disabled');
 
     cy.get('[data-cy="Diagnosis-categorical-field"]').type('parkin{downarrow}{enter}');
-    cy.get('[data-cy="Diagnosis-categorical-field"] input').should(
-      'have.value',
-      "Parkinson's disease"
-    );
+    cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
     cy.get('[data-cy="query-form-changed-alert"]').should('be.visible');
     cy.get('[data-cy="download-results-button"]').should('be.disabled');
 
     cy.get('[data-cy="query-form-changed-alert"]').contains('button', 'Undo changes').click();
 
     cy.get('[data-cy="query-form-changed-alert"]').should('not.exist');
-    cy.get('[data-cy="Diagnosis-categorical-field"] input').should('have.value', '');
+    cy.get('[data-cy="Diagnosis-categorical-field"]').should('not.contain', "Parkinson's disease");
     cy.get('[data-cy="download-results-button"]').should('not.be.disabled');
   });
 });

--- a/cypress/e2e/UndoQueryFormChanges.cy.ts
+++ b/cypress/e2e/UndoQueryFormChanges.cy.ts
@@ -12,6 +12,7 @@ describe('Undo cohort changes', () => {
     cy.intercept('GET', '/diagnoses', diagnosisOptions).as('getDiagnoses');
     cy.intercept('GET', '/assessments', assessmentToolOptions).as('getAssessments');
     cy.intercept('GET', '/pipelines', pipelineOptions).as('getPipelines');
+    cy.intercept('GET', '/pipelines/*/versions', []).as('getPipelineVersions');
     cy.intercept('POST', '/datasets', protectedResponse2).as('datasetsQuery');
 
     cy.visit('/');
@@ -43,7 +44,8 @@ describe('Undo cohort changes', () => {
     cy.get('[data-cy="card-https://someportal.org/datasets/ds0001-checkbox"] input').check();
     cy.get('[data-cy="download-results-button"]').should('not.be.disabled');
 
-    cy.get('[data-cy="Diagnosis-categorical-field"]').type('parkin{downarrow}{enter}');
+    cy.get('[data-cy="Diagnosis-categorical-field"]').click();
+    cy.contains('.MuiAutocomplete-option', "Parkinson's disease").click();
     cy.get('[data-cy="Diagnosis-categorical-field"]').should('contain', "Parkinson's disease");
     cy.get('[data-cy="query-form-changed-alert"]').should('be.visible');
     cy.get('[data-cy="download-results-button"]').should('be.disabled');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,19 +307,23 @@ function App() {
       }
     }
 
-    const selectedPipelineNames = normalizeFieldInputOptions(pipelineName);
+    const pipelineURIs = Object.keys(pipelines);
 
-    selectedPipelineNames.forEach((p) => {
-      if (pipelines[p.id] == null || pipelines[p.id].length === 0) {
-        getPipelineVersions(p).then((pipelineVersionsResponse) => {
+    pipelineURIs.forEach((pId) => {
+      if (pipelines[pId] == null || pipelines[pId].length === 0) {
+        const pOption: FieldInputOption = {
+          id: pId,
+          label: pId.startsWith('np:') ? pId.slice(3) : pId,
+        };
+        getPipelineVersions(pOption).then((pipelineVersionsResponse) => {
           setPipelines((prevPipelines) => ({
             ...prevPipelines,
-            [p.id]: pipelineVersionsResponse,
+            [pId]: pipelineVersionsResponse,
           }));
         });
       }
     });
-  }, [pipelines, pipelineName]);
+  }, [pipelines]);
 
   useEffect(() => {
     if (availableNodes.length > 1) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import NodeAdmonition from './components/NodeAdmonition';
 import './App.css';
 import logo from './assets/logo.png';
 import areFormStatesEqual, {
+  normalizeFieldInputOptions,
   parseNumericValue,
   sendDatasetsQuery,
   sendSubjectsQuery,
@@ -306,11 +307,7 @@ function App() {
       }
     }
 
-    const selectedPipelineNames: FieldInputOption[] = Array.isArray(pipelineName)
-      ? pipelineName
-      : pipelineName
-        ? [pipelineName]
-        : [];
+    const selectedPipelineNames = normalizeFieldInputOptions(pipelineName);
 
     selectedPipelineNames.forEach((p) => {
       if (pipelines[p.id] == null || pipelines[p.id].length === 0) {
@@ -405,16 +402,10 @@ function App() {
         break;
       case 'Pipeline name': {
         setPipelineName(value);
-        const newSelectedPipelines: FieldInputOption[] = Array.isArray(value)
-          ? value
-          : value
-            ? [value]
-            : [];
+        const newSelectedPipelines = normalizeFieldInputOptions(value);
         const newPipelineIds = new Set(newSelectedPipelines.map((p) => p.id));
         if (pipelineVersion) {
-          const currentVersions: FieldInputOption[] = Array.isArray(pipelineVersion)
-            ? pipelineVersion
-            : [pipelineVersion];
+          const currentVersions = normalizeFieldInputOptions(pipelineVersion);
           const validVersions = currentVersions.filter((v) => {
             const pId = v.id.includes('::') ? v.id.split('::')[0] : '';
             return newPipelineIds.has(pId);
@@ -470,11 +461,9 @@ function App() {
     if (maxAgeNumber !== null) requestBody.max_age = maxAgeNumber;
     if (sex && !Array.isArray(sex)) requestBody.sex = sex.id;
 
-    if (diagnosis) {
-      const diagArray = Array.isArray(diagnosis) ? diagnosis : [diagnosis];
-      if (diagArray.length > 0) {
-        requestBody.diagnosis = diagArray.map((d) => d.id);
-      }
+    const diagArray = normalizeFieldInputOptions(diagnosis);
+    if (diagArray.length > 0) {
+      requestBody.diagnosis = diagArray.map((d) => d.id);
     }
 
     const minNumImagingSessionsNumber = parseNumericValue(minNumImagingSessions);
@@ -485,32 +474,20 @@ function App() {
     if (minNumPhenotypicSessionsNumber !== null)
       requestBody.min_num_phenotypic_sessions = minNumPhenotypicSessionsNumber;
 
-    if (assessmentTool) {
-      const assessArray = Array.isArray(assessmentTool) ? assessmentTool : [assessmentTool];
-      if (assessArray.length > 0) {
-        requestBody.assessment = assessArray.map((a) => a.id);
-      }
+    const assessArray = normalizeFieldInputOptions(assessmentTool);
+    if (assessArray.length > 0) {
+      requestBody.assessment = assessArray.map((a) => a.id);
     }
 
-    if (imagingModality) {
-      const modalArray = Array.isArray(imagingModality) ? imagingModality : [imagingModality];
-      if (modalArray.length > 0) {
-        requestBody.image_modal = modalArray.map((m) => m.id);
-      }
+    const modalArray = normalizeFieldInputOptions(imagingModality);
+    if (modalArray.length > 0) {
+      requestBody.image_modal = modalArray.map((m) => m.id);
     }
 
-    const selectedPipelines: FieldInputOption[] = Array.isArray(pipelineName)
-      ? pipelineName
-      : pipelineName
-        ? [pipelineName]
-        : [];
+    const selectedPipelines = normalizeFieldInputOptions(pipelineName);
 
     if (selectedPipelines.length > 0) {
-      const selectedVersions: FieldInputOption[] = Array.isArray(pipelineVersion)
-        ? pipelineVersion
-        : pipelineVersion
-          ? [pipelineVersion]
-          : [];
+      const selectedVersions = normalizeFieldInputOptions(pipelineVersion);
 
       requestBody.pipeline = selectedPipelines.flatMap((p) => {
         const pVersions = selectedVersions.filter(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,21 +305,23 @@ function App() {
         return [];
       }
     }
-    // Get pipeline versions if
-    // 1. A pipeline has been selected (this implementation only works for single value for pipeline name field)
-    // 2. This is the first time its being selected (i.e., we haven't retrieved pipeline versions before)
-    if (
-      pipelineName !== null &&
-      !Array.isArray(pipelineName) &&
-      pipelines[pipelineName.id].length === 0
-    ) {
-      getPipelineVersions(pipelineName).then((pipelineVersionsRespnse) => {
-        setPipelines((prevPipelines) => ({
-          ...prevPipelines,
-          [pipelineName.id]: pipelineVersionsRespnse,
-        }));
-      });
-    }
+
+    const selectedPipelineNames: FieldInputOption[] = Array.isArray(pipelineName)
+      ? pipelineName
+      : pipelineName
+        ? [pipelineName]
+        : [];
+
+    selectedPipelineNames.forEach((p) => {
+      if (pipelines[p.id] == null || pipelines[p.id].length === 0) {
+        getPipelineVersions(p).then((pipelineVersionsResponse) => {
+          setPipelines((prevPipelines) => ({
+            ...prevPipelines,
+            [p.id]: pipelineVersionsResponse,
+          }));
+        });
+      }
+    });
   }, [pipelines, pipelineName]);
 
   useEffect(() => {
@@ -401,9 +403,26 @@ function App() {
       case 'Pipeline version':
         setPipelineVersion(value);
         break;
-      case 'Pipeline name':
+      case 'Pipeline name': {
         setPipelineName(value);
+        const newSelectedPipelines: FieldInputOption[] = Array.isArray(value)
+          ? value
+          : value
+            ? [value]
+            : [];
+        const newPipelineIds = new Set(newSelectedPipelines.map((p) => p.id));
+        if (pipelineVersion) {
+          const currentVersions: FieldInputOption[] = Array.isArray(pipelineVersion)
+            ? pipelineVersion
+            : [pipelineVersion];
+          const validVersions = currentVersions.filter((v) => {
+            const pId = v.id.includes('::') ? v.id.split('::')[0] : '';
+            return newPipelineIds.has(pId);
+          });
+          setPipelineVersion(validVersions.length > 0 ? validVersions : null);
+        }
         break;
+      }
       default:
         break;
     }
@@ -450,7 +469,14 @@ function App() {
     const maxAgeNumber = parseNumericValue(maxAge);
     if (maxAgeNumber !== null) requestBody.max_age = maxAgeNumber;
     if (sex && !Array.isArray(sex)) requestBody.sex = sex.id;
-    if (diagnosis && !Array.isArray(diagnosis)) requestBody.diagnosis = diagnosis.id;
+
+    if (diagnosis) {
+      const diagArray = Array.isArray(diagnosis) ? diagnosis : [diagnosis];
+      if (diagArray.length > 0) {
+        requestBody.diagnosis = diagArray.map((d) => d.id);
+      }
+    }
+
     const minNumImagingSessionsNumber = parseNumericValue(minNumImagingSessions);
     if (minNumImagingSessionsNumber !== null)
       requestBody.min_num_imaging_sessions = minNumImagingSessionsNumber;
@@ -458,13 +484,48 @@ function App() {
     const minNumPhenotypicSessionsNumber = parseNumericValue(minNumPhenotypicSessions);
     if (minNumPhenotypicSessionsNumber !== null)
       requestBody.min_num_phenotypic_sessions = minNumPhenotypicSessionsNumber;
-    if (assessmentTool && !Array.isArray(assessmentTool))
-      requestBody.assessment = assessmentTool.id;
-    if (imagingModality && !Array.isArray(imagingModality))
-      requestBody.image_modal = imagingModality.id;
-    if (pipelineName && !Array.isArray(pipelineName)) requestBody.pipeline_name = pipelineName.id;
-    if (pipelineVersion && !Array.isArray(pipelineVersion) && pipelineName)
-      requestBody.pipeline_version = pipelineVersion.id;
+
+    if (assessmentTool) {
+      const assessArray = Array.isArray(assessmentTool) ? assessmentTool : [assessmentTool];
+      if (assessArray.length > 0) {
+        requestBody.assessment = assessArray.map((a) => a.id);
+      }
+    }
+
+    if (imagingModality) {
+      const modalArray = Array.isArray(imagingModality) ? imagingModality : [imagingModality];
+      if (modalArray.length > 0) {
+        requestBody.image_modal = modalArray.map((m) => m.id);
+      }
+    }
+
+    const selectedPipelines: FieldInputOption[] = Array.isArray(pipelineName)
+      ? pipelineName
+      : pipelineName
+        ? [pipelineName]
+        : [];
+
+    if (selectedPipelines.length > 0) {
+      const selectedVersions: FieldInputOption[] = Array.isArray(pipelineVersion)
+        ? pipelineVersion
+        : pipelineVersion
+          ? [pipelineVersion]
+          : [];
+
+      requestBody.pipeline = selectedPipelines.flatMap((p) => {
+        const pVersions = selectedVersions.filter(
+          (v) =>
+            v.id.startsWith(`${p.id}::`) || (selectedPipelines.length === 1 && !v.id.includes('::'))
+        );
+        if (pVersions.length > 0) {
+          return pVersions.map((v) => {
+            const versionStr = v.id.includes('::') ? v.id.split('::')[1] : v.id;
+            return { name: p.id, version: versionStr };
+          });
+        }
+        return [{ name: p.id }];
+      });
+    }
 
     return requestBody;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -494,15 +494,12 @@ function App() {
       const selectedVersions = normalizeFieldInputOptions(pipelineVersion);
 
       requestBody.pipeline = selectedPipelines.flatMap((p) => {
-        const pVersions = selectedVersions.filter(
-          (v) =>
-            v.id.startsWith(`${p.id}::`) || (selectedPipelines.length === 1 && !v.id.includes('::'))
-        );
+        const pVersions = selectedVersions.filter((v) => v.id.startsWith(`${p.id}::`));
         if (pVersions.length > 0) {
-          return pVersions.map((v) => {
-            const versionStr = v.id.includes('::') ? v.id.split('::')[1] : v.id;
-            return { name: p.id, version: versionStr };
-          });
+          return pVersions.map((v) => ({
+            name: p.id,
+            version: v.id.split('::')[1],
+          }));
         }
         return [{ name: p.id }];
       });

--- a/src/components/CategoricalField.tsx
+++ b/src/components/CategoricalField.tsx
@@ -1,5 +1,6 @@
 import { Autocomplete, Checkbox, TextField } from '@mui/material';
 import { CategoricalFieldProps, CategoricalFieldOption } from '../utils/types';
+import { normalizeFieldInputOptions } from '../utils/utils';
 
 function CategoricalField({
   label,
@@ -11,15 +12,8 @@ function CategoricalField({
   groupBy,
   renderGroup,
 }: CategoricalFieldProps) {
-  const normalizedValue = multiple
-    ? Array.isArray(inputValue)
-      ? inputValue
-      : inputValue
-        ? [inputValue]
-        : []
-    : Array.isArray(inputValue)
-      ? (inputValue[0] ?? null)
-      : inputValue;
+  const normalizedOptions = normalizeFieldInputOptions(inputValue);
+  const normalizedValue = multiple ? normalizedOptions : (normalizedOptions[0] ?? null);
 
   const hasGroups = options.some((opt) => opt.group != null);
   const sortedOptions = [...options].sort((a, b) => {

--- a/src/components/CategoricalField.tsx
+++ b/src/components/CategoricalField.tsx
@@ -9,6 +9,7 @@ function CategoricalField({
   inputValue,
   disabled = false,
   groupBy,
+  renderGroup,
 }: CategoricalFieldProps) {
   const normalizedValue = multiple
     ? Array.isArray(inputValue)
@@ -41,6 +42,7 @@ function CategoricalField({
       groupBy={
         groupBy || (hasGroups ? (option: CategoricalFieldOption) => option.group ?? '' : undefined)
       }
+      renderGroup={renderGroup}
       onChange={(_, value) => onFieldChange(label, value)}
       disabled={disabled}
     />

--- a/src/components/CategoricalField.tsx
+++ b/src/components/CategoricalField.tsx
@@ -1,5 +1,5 @@
 import { Autocomplete, TextField } from '@mui/material';
-import { CategoricalFieldProps } from '../utils/types';
+import { CategoricalFieldProps, CategoricalFieldOption } from '../utils/types';
 
 function CategoricalField({
   label,
@@ -8,17 +8,39 @@ function CategoricalField({
   multiple = false,
   inputValue,
   disabled = false,
+  groupBy,
 }: CategoricalFieldProps) {
+  const normalizedValue = multiple
+    ? Array.isArray(inputValue)
+      ? inputValue
+      : inputValue
+        ? [inputValue]
+        : []
+    : Array.isArray(inputValue)
+      ? (inputValue[0] ?? null)
+      : inputValue;
+
+  const hasGroups = options.some((opt) => opt.group != null);
+  const sortedOptions = [...options].sort((a, b) => {
+    if (a.group && b.group && a.group !== b.group) {
+      return a.group.localeCompare(b.group);
+    }
+    return a.label.localeCompare(b.label);
+  });
+
   return (
     <Autocomplete
       data-cy={`${label}-categorical-field`}
-      options={options.sort((a, b) => a.label.localeCompare(b.label))}
+      options={sortedOptions}
       isOptionEqualToValue={(option, value) => option.id === value.id}
-      value={inputValue}
+      value={normalizedValue}
       renderInput={(params) => (
         <TextField {...params} label={label} placeholder="Select an option" />
       )}
       multiple={multiple}
+      groupBy={
+        groupBy || (hasGroups ? (option: CategoricalFieldOption) => option.group ?? '' : undefined)
+      }
       onChange={(_, value) => onFieldChange(label, value)}
       disabled={disabled}
     />

--- a/src/components/CategoricalField.tsx
+++ b/src/components/CategoricalField.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, TextField } from '@mui/material';
+import { Autocomplete, Checkbox, TextField } from '@mui/material';
 import { CategoricalFieldProps, CategoricalFieldOption } from '../utils/types';
 
 function CategoricalField({
@@ -39,10 +39,20 @@ function CategoricalField({
         <TextField {...params} label={label} placeholder="Select an option" />
       )}
       multiple={multiple}
+      disableCloseOnSelect={multiple}
       groupBy={
         groupBy || (hasGroups ? (option: CategoricalFieldOption) => option.group ?? '' : undefined)
       }
       renderGroup={renderGroup}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key ?? option.id} {...optionProps}>
+            <Checkbox size="small" sx={{ mr: 1 }} checked={selected} />
+            {option.label}
+          </li>
+        );
+      }}
       onChange={(_, value) => onFieldChange(label, value)}
       disabled={disabled}
     />

--- a/src/components/CollapsiblePipelineGroup.tsx
+++ b/src/components/CollapsiblePipelineGroup.tsx
@@ -1,38 +1,34 @@
-import { useState } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Checkbox,
-  Typography,
-  AutocompleteRenderGroupParams,
-} from '@mui/material';
+import { useState, ReactNode } from 'react';
+import { Accordion, AccordionDetails, AccordionSummary, Checkbox, Typography } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { FieldInputOption } from '../utils/types';
 
 interface CollapsiblePipelineGroupProps {
-  params: AutocompleteRenderGroupParams;
+  groupKey: string | number;
+  groupLabel: string;
+  children: ReactNode;
   selectedPipelines: FieldInputOption[];
   selectedVersions: FieldInputOption[];
   onTogglePipeline: (pId: string, pLabel: string) => void;
 }
 
 function CollapsiblePipelineGroup({
-  params,
+  groupKey,
+  groupLabel,
+  children,
   selectedPipelines,
   selectedVersions,
   onTogglePipeline,
 }: CollapsiblePipelineGroupProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const pLabel = params.group;
-  const isPipelineInName = selectedPipelines.some((p) => p.label === pLabel);
-  const pId = selectedPipelines.find((p) => p.label === pLabel)?.id ?? `np:${pLabel}`;
+  const isPipelineInName = selectedPipelines.some((p) => p.label === groupLabel);
+  const pId = selectedPipelines.find((p) => p.label === groupLabel)?.id ?? `np:${groupLabel}`;
   const hasSelectedVersion = selectedVersions.some((v) => v.id.startsWith(`${pId}::`));
 
   const isPipelineChecked = isPipelineInName && !hasSelectedVersion;
 
   return (
-    <li key={params.key}>
+    <li key={groupKey}>
       <Accordion
         expanded={isExpanded}
         onChange={() => setIsExpanded((prev) => !prev)}
@@ -66,15 +62,15 @@ function CollapsiblePipelineGroup({
             checked={isPipelineChecked}
             onClick={(e) => {
               e.stopPropagation();
-              onTogglePipeline(pId, pLabel);
+              onTogglePipeline(pId, groupLabel);
             }}
           />
           <Typography variant="body2" fontWeight={600} sx={{ ml: 0.5 }}>
-            {pLabel}
+            {groupLabel}
           </Typography>
         </AccordionSummary>
         <AccordionDetails sx={{ p: 0 }}>
-          <ul>{params.children}</ul>
+          <ul>{children}</ul>
         </AccordionDetails>
       </Accordion>
     </li>

--- a/src/components/CollapsiblePipelineGroup.tsx
+++ b/src/components/CollapsiblePipelineGroup.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Checkbox,
+  Typography,
+  AutocompleteRenderGroupParams,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { FieldInputOption } from '../utils/types';
+
+interface CollapsiblePipelineGroupProps {
+  params: AutocompleteRenderGroupParams;
+  selectedPipelines: FieldInputOption[];
+  selectedVersions: FieldInputOption[];
+  onTogglePipeline: (pId: string, pLabel: string) => void;
+}
+
+function CollapsiblePipelineGroup({
+  params,
+  selectedPipelines,
+  selectedVersions,
+  onTogglePipeline,
+}: CollapsiblePipelineGroupProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const pLabel = params.group;
+  const isPipelineInName = selectedPipelines.some((p) => p.label === pLabel);
+  const pId = selectedPipelines.find((p) => p.label === pLabel)?.id ?? `np:${pLabel}`;
+  const hasSelectedVersion = selectedVersions.some((v) => v.id.startsWith(`${pId}::`));
+
+  const isPipelineChecked = isPipelineInName && !hasSelectedVersion;
+
+  return (
+    <li key={params.key}>
+      <Accordion
+        expanded={isExpanded}
+        onChange={() => setIsExpanded((prev) => !prev)}
+        elevation={0}
+        square
+        disableGutters
+        sx={{
+          backgroundColor: 'transparent',
+          '&:before': { display: 'none' },
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon fontSize="small" />}
+          sx={{
+            minHeight: 36,
+            maxHeight: 36,
+            px: 1,
+            py: 0,
+            '&.Mui-expanded': { minHeight: 36, maxHeight: 36 },
+            '&:hover': { backgroundColor: 'action.hover' },
+            '.MuiAccordionSummary-content': {
+              my: 0,
+              alignItems: 'center',
+              '&.Mui-expanded': { my: 0 },
+            },
+          }}
+        >
+          <Checkbox
+            data-cy={`pipeline-group-${pId}-checkbox`}
+            size="small"
+            checked={isPipelineChecked}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTogglePipeline(pId, pLabel);
+            }}
+          />
+          <Typography variant="body2" fontWeight={600} sx={{ ml: 0.5 }}>
+            {pLabel}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ p: 0 }}>
+          <ul>{params.children}</ul>
+        </AccordionDetails>
+      </Accordion>
+    </li>
+  );
+}
+
+export default CollapsiblePipelineGroup;

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -4,6 +4,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Button,
+  Checkbox,
   CircularProgress,
   FormHelperText,
   Typography,
@@ -26,11 +27,30 @@ import CategoricalField from './CategoricalField';
 import ContinuousField from './ContinuousField';
 import GetDataDialog from './GetDataDialog';
 
-function CollapsiblePipelineGroup(params: AutocompleteRenderGroupParams) {
+function CollapsiblePipelineGroup({
+  params,
+  selectedPipelines,
+  selectedVersions,
+  onTogglePipeline,
+}: {
+  params: AutocompleteRenderGroupParams;
+  selectedPipelines: FieldInputOption[];
+  selectedVersions: FieldInputOption[];
+  onTogglePipeline: (pId: string, pLabel: string) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const pLabel = params.group;
+  const isPipelineInName = selectedPipelines.some((p) => p.label === pLabel);
+  const pId = selectedPipelines.find((p) => p.label === pLabel)?.id ?? `np:${pLabel}`;
+  const hasSelectedVersion = selectedVersions.some((v) => v.id.startsWith(`${pId}::`));
+
+  const isPipelineChecked = isPipelineInName && !hasSelectedVersion;
+
   return (
     <li key={params.key}>
       <Accordion
-        defaultExpanded
+        expanded={isExpanded}
+        onChange={() => setIsExpanded((prev) => !prev)}
         elevation={0}
         square
         disableGutters
@@ -44,15 +64,27 @@ function CollapsiblePipelineGroup(params: AutocompleteRenderGroupParams) {
           sx={{
             minHeight: 36,
             maxHeight: 36,
-            px: 2,
+            px: 1,
             py: 0,
             '&.Mui-expanded': { minHeight: 36, maxHeight: 36 },
             '&:hover': { backgroundColor: 'action.hover' },
-            '.MuiAccordionSummary-content': { my: 0, '&.Mui-expanded': { my: 0 } },
+            '.MuiAccordionSummary-content': {
+              my: 0,
+              alignItems: 'center',
+              '&.Mui-expanded': { my: 0 },
+            },
           }}
         >
-          <Typography variant="body2" fontWeight={600}>
-            {params.group}
+          <Checkbox
+            size="small"
+            checked={isPipelineChecked}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTogglePipeline(pId, pLabel);
+            }}
+          />
+          <Typography variant="body2" fontWeight={600} sx={{ ml: 0.5 }}>
+            {pLabel}
           </Typography>
         </AccordionSummary>
         <AccordionDetails sx={{ p: 0 }}>
@@ -152,23 +184,21 @@ function QueryForm({
       const pLabel = pId.startsWith('np:') ? pId.slice(3) : pId;
       const versions = pipelines[pId] ?? [];
 
-      const pOptions: CategoricalFieldOption[] = [
-        {
-          label: `${pLabel} (Any version)`,
-          id: pId,
-          group: pLabel,
-        },
-      ];
+      if (versions.length === 0) {
+        return [
+          {
+            label: pLabel,
+            id: pId,
+            group: pLabel,
+          },
+        ];
+      }
 
-      versions.forEach((v) => {
-        pOptions.push({
-          label: `${pLabel} - ${v}`,
-          id: `${pId}::${v}`,
-          group: pLabel,
-        });
-      });
-
-      return pOptions;
+      return versions.map((v) => ({
+        label: `${pLabel} ${v}`,
+        id: `${pId}::${v}`,
+        group: pLabel,
+      }));
     }
   );
 
@@ -186,12 +216,41 @@ function QueryForm({
     }
     return [
       {
-        label: `${p.label} (Any version)`,
+        label: p.label,
         id: p.id,
         group: p.label,
       },
     ];
   });
+
+  const handleTogglePipeline = (pId: string, pLabel: string) => {
+    const hasSelectedVersion = selectedVersionsAll.some((v) => v.id.startsWith(`${pId}::`));
+    const isPipelineInName = selectedPipelines.some((p) => p.id === pId);
+    const isHeaderChecked = isPipelineInName && !hasSelectedVersion;
+
+    let updatedPipelines: FieldInputOption[];
+    let updatedVersions: FieldInputOption[];
+
+    if (isHeaderChecked) {
+      updatedPipelines = selectedPipelines.filter((p) => p.id !== pId);
+      updatedVersions = selectedVersionsAll.filter((v) => !v.id.startsWith(`${pId}::`));
+    } else {
+      const exists = selectedPipelines.some((p) => p.id === pId);
+      updatedPipelines = exists
+        ? selectedPipelines
+        : [...selectedPipelines, { id: pId, label: pLabel }];
+      updatedVersions = selectedVersionsAll.filter((v) => !v.id.startsWith(`${pId}::`));
+    }
+
+    updateCategoricalQueryParams(
+      'Pipeline name',
+      updatedPipelines.length > 0 ? updatedPipelines : null
+    );
+    updateCategoricalQueryParams(
+      'Pipeline version',
+      updatedVersions.length > 0 ? updatedVersions : null
+    );
+  };
 
   const handleCombinedPipelineChange = (selectedOptionsInput: FieldInput) => {
     const selectedOptions = normalizeFieldInputOptions(selectedOptionsInput);
@@ -213,7 +272,7 @@ function QueryForm({
         updatedVersions.push({ id: opt.id, label: opt.label });
       } else {
         const pId = opt.id;
-        const pLabel = opt.label.replace(' (Any version)', '');
+        const pLabel = opt.group ?? (pId.startsWith('np:') ? pId.slice(3) : pId);
         updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
       }
     });
@@ -336,7 +395,14 @@ function QueryForm({
           onFieldChange={(_, value) => handleCombinedPipelineChange(value)}
           multiple
           inputValue={combinedInputValue}
-          renderGroup={(params) => <CollapsiblePipelineGroup {...params} />}
+          renderGroup={(params) => (
+            <CollapsiblePipelineGroup
+              params={params}
+              selectedPipelines={selectedPipelines}
+              selectedVersions={selectedVersionsAll}
+              onTogglePipeline={handleTogglePipeline}
+            />
+          )}
         />
       </div>
 

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -188,7 +188,7 @@ function QueryForm({
       if (versions.length === 0) {
         return [
           {
-            label: pLabel,
+            label: `${pLabel} any version`,
             id: pId,
             group: pLabel,
           },
@@ -217,7 +217,7 @@ function QueryForm({
     }
     return [
       {
-        label: p.label,
+        label: `${p.label} any version`,
         id: p.id,
         group: p.label,
       },

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -180,9 +180,13 @@ function QueryForm({
     maxAgeHelperText !== '' ||
     minNumImagingSessionsHelperText !== '';
 
-  const pipelineCombinedOptions: CategoricalFieldOption[] = Object.keys(pipelines).flatMap(
-    (pId) => {
-      const pLabel = pId.startsWith('np:') ? pId.slice(3) : pId;
+  function getPipelineLabel(pId: string): string {
+    return pId.startsWith('np:') ? pId.slice(3) : pId;
+  }
+
+  function buildPipelineCombinedOptions(pipelines: Pipelines): CategoricalFieldOption[] {
+    return Object.keys(pipelines).flatMap((pId) => {
+      const pLabel = getPipelineLabel(pId);
       const versions = pipelines[pId] ?? [];
 
       if (versions.length === 0) {
@@ -200,29 +204,36 @@ function QueryForm({
         id: `${pId}::${v}`,
         group: pLabel,
       }));
-    }
-  );
+    });
+  }
 
+  function buildCombinedInputValue(
+    selectedPipelines: FieldInputOption[],
+    selectedVersionsAll: FieldInputOption[]
+  ): CategoricalFieldOption[] {
+    return selectedPipelines.flatMap((p) => {
+      const pVersions = selectedVersionsAll.filter((v) => v.id.startsWith(`${p.id}::`));
+      if (pVersions.length > 0) {
+        return pVersions.map((v) => ({
+          label: v.label,
+          id: v.id,
+          group: p.label,
+        }));
+      }
+      return [
+        {
+          label: `${p.label} any version`,
+          id: p.id,
+          group: p.label,
+        },
+      ];
+    });
+  }
+
+  const pipelineCombinedOptions = buildPipelineCombinedOptions(pipelines);
   const selectedPipelines = normalizeFieldInputOptions(pipelineName);
   const selectedVersionsAll = normalizeFieldInputOptions(pipelineVersion);
-
-  const combinedInputValue: CategoricalFieldOption[] = selectedPipelines.flatMap((p) => {
-    const pVersions = selectedVersionsAll.filter((v) => v.id.startsWith(`${p.id}::`));
-    if (pVersions.length > 0) {
-      return pVersions.map((v) => ({
-        label: v.label,
-        id: v.id,
-        group: p.label,
-      }));
-    }
-    return [
-      {
-        label: `${p.label} any version`,
-        id: p.id,
-        group: p.label,
-      },
-    ];
-  });
+  const combinedInputValue = buildCombinedInputValue(selectedPipelines, selectedVersionsAll);
 
   const handleTogglePipeline = (pId: string, pLabel: string) => {
     const hasSelectedVersion = selectedVersionsAll.some((v) => v.id.startsWith(`${pId}::`));
@@ -266,15 +277,13 @@ function QueryForm({
     const updatedVersions: FieldInputOption[] = [];
 
     (selectedOptions as CategoricalFieldOption[]).forEach((opt) => {
-      if (opt.id.includes('::')) {
-        const pId = opt.id.split('::')[0];
-        const pLabel = opt.group ?? (pId.startsWith('np:') ? pId.slice(3) : pId);
-        updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
+      const isVersionOption = opt.id.includes('::');
+      const pId = isVersionOption ? opt.id.split('::')[0] : opt.id;
+      const pLabel = opt.group ?? getPipelineLabel(pId);
+
+      updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
+      if (isVersionOption) {
         updatedVersions.push({ id: opt.id, label: opt.label });
-      } else {
-        const pId = opt.id;
-        const pLabel = opt.group ?? (pId.startsWith('np:') ? pId.slice(3) : pId);
-        updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
       }
     });
 

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -5,12 +5,11 @@ import { sexes } from '../utils/constants';
 import {
   NodeOption,
   AttributeOption,
-  FieldInputOption,
   FieldInput,
   Pipelines,
   ImagingModalityOption,
 } from '../utils/types';
-import { parseNumericValue } from '../utils/utils';
+import { parseNumericValue, normalizeFieldInputOptions } from '../utils/utils';
 import CategoricalField from './CategoricalField';
 import ContinuousField from './ContinuousField';
 import GetDataDialog from './GetDataDialog';
@@ -212,11 +211,7 @@ function QueryForm({
         />
       </div>
       {(() => {
-        const selectedPipelines: FieldInputOption[] = Array.isArray(pipelineName)
-          ? pipelineName
-          : pipelineName
-            ? [pipelineName]
-            : [];
+        const selectedPipelines = normalizeFieldInputOptions(pipelineName);
 
         if (selectedPipelines.length === 0) {
           return (

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -1,17 +1,6 @@
 import { useState } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Button,
-  Checkbox,
-  CircularProgress,
-  FormHelperText,
-  Typography,
-  AutocompleteRenderGroupParams,
-} from '@mui/material';
+import { Button, CircularProgress, FormHelperText } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { sexes } from '../utils/constants';
 import {
   NodeOption,
@@ -22,79 +11,18 @@ import {
   Pipelines,
   ImagingModalityOption,
 } from '../utils/types';
-import { parseNumericValue, normalizeFieldInputOptions } from '../utils/utils';
+import {
+  parseNumericValue,
+  normalizeFieldInputOptions,
+  validateContinuousValue,
+  getPipelineLabel,
+  buildPipelineCombinedOptions,
+  buildCombinedInputValue,
+} from '../utils/utils';
 import CategoricalField from './CategoricalField';
 import ContinuousField from './ContinuousField';
 import GetDataDialog from './GetDataDialog';
-
-function CollapsiblePipelineGroup({
-  params,
-  selectedPipelines,
-  selectedVersions,
-  onTogglePipeline,
-}: {
-  params: AutocompleteRenderGroupParams;
-  selectedPipelines: FieldInputOption[];
-  selectedVersions: FieldInputOption[];
-  onTogglePipeline: (pId: string, pLabel: string) => void;
-}) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const pLabel = params.group;
-  const isPipelineInName = selectedPipelines.some((p) => p.label === pLabel);
-  const pId = selectedPipelines.find((p) => p.label === pLabel)?.id ?? `np:${pLabel}`;
-  const hasSelectedVersion = selectedVersions.some((v) => v.id.startsWith(`${pId}::`));
-
-  const isPipelineChecked = isPipelineInName && !hasSelectedVersion;
-
-  return (
-    <li key={params.key}>
-      <Accordion
-        expanded={isExpanded}
-        onChange={() => setIsExpanded((prev) => !prev)}
-        elevation={0}
-        square
-        disableGutters
-        sx={{
-          backgroundColor: 'transparent',
-          '&:before': { display: 'none' },
-        }}
-      >
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon fontSize="small" />}
-          sx={{
-            minHeight: 36,
-            maxHeight: 36,
-            px: 1,
-            py: 0,
-            '&.Mui-expanded': { minHeight: 36, maxHeight: 36 },
-            '&:hover': { backgroundColor: 'action.hover' },
-            '.MuiAccordionSummary-content': {
-              my: 0,
-              alignItems: 'center',
-              '&.Mui-expanded': { my: 0 },
-            },
-          }}
-        >
-          <Checkbox
-            data-cy={`pipeline-group-${pId}-checkbox`}
-            size="small"
-            checked={isPipelineChecked}
-            onClick={(e) => {
-              e.stopPropagation();
-              onTogglePipeline(pId, pLabel);
-            }}
-          />
-          <Typography variant="body2" fontWeight={600} sx={{ ml: 0.5 }}>
-            {pLabel}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails sx={{ p: 0 }}>
-          <ul>{params.children}</ul>
-        </AccordionDetails>
-      </Accordion>
-    </li>
-  );
-}
+import CollapsiblePipelineGroup from './CollapsiblePipelineGroup';
 
 function QueryForm({
   availableNodes,
@@ -141,21 +69,6 @@ function QueryForm({
 }) {
   const [openDialog, setOpenDialog] = useState(false);
 
-  function validateContinuousValue(rawValue: string, parsedValue: number | null) {
-    const trimmed = rawValue.trim();
-    if (trimmed === '') {
-      // Value is default, user has not entered anything yet
-      return '';
-    }
-    if (parsedValue === null) {
-      return 'Please enter a valid number!';
-    }
-    if (parsedValue < 0) {
-      return 'Please enter a positive number!';
-    }
-    return '';
-  }
-
   const parsedMinAge = parseNumericValue(minAge);
   const parsedMaxAge = parseNumericValue(maxAge);
   const parsedMinNumImagingSessions = parseNumericValue(minNumImagingSessions);
@@ -179,56 +92,6 @@ function QueryForm({
     minAgeHelperText !== '' ||
     maxAgeHelperText !== '' ||
     minNumImagingSessionsHelperText !== '';
-
-  function getPipelineLabel(pId: string): string {
-    return pId.startsWith('np:') ? pId.slice(3) : pId;
-  }
-
-  function buildPipelineCombinedOptions(pipelines: Pipelines): CategoricalFieldOption[] {
-    return Object.keys(pipelines).flatMap((pId) => {
-      const pLabel = getPipelineLabel(pId);
-      const versions = pipelines[pId] ?? [];
-
-      if (versions.length === 0) {
-        return [
-          {
-            label: `${pLabel} any version`,
-            id: pId,
-            group: pLabel,
-          },
-        ];
-      }
-
-      return versions.map((v) => ({
-        label: `${pLabel} ${v}`,
-        id: `${pId}::${v}`,
-        group: pLabel,
-      }));
-    });
-  }
-
-  function buildCombinedInputValue(
-    selectedPipelines: FieldInputOption[],
-    selectedVersionsAll: FieldInputOption[]
-  ): CategoricalFieldOption[] {
-    return selectedPipelines.flatMap((p) => {
-      const pVersions = selectedVersionsAll.filter((v) => v.id.startsWith(`${p.id}::`));
-      if (pVersions.length > 0) {
-        return pVersions.map((v) => ({
-          label: v.label,
-          id: v.id,
-          group: p.label,
-        }));
-      }
-      return [
-        {
-          label: `${p.label} any version`,
-          id: p.id,
-          group: p.label,
-        },
-      ];
-    });
-  }
 
   const pipelineCombinedOptions = buildPipelineCombinedOptions(pipelines);
   const selectedPipelines = normalizeFieldInputOptions(pipelineName);

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -38,7 +38,7 @@ function CollapsiblePipelineGroup({
   selectedVersions: FieldInputOption[];
   onTogglePipeline: (pId: string, pLabel: string) => void;
 }) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const pLabel = params.group;
   const isPipelineInName = selectedPipelines.some((p) => p.label === pLabel);
   const pId = selectedPipelines.find((p) => p.label === pLabel)?.id ?? `np:${pLabel}`;

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -268,13 +268,17 @@ function QueryForm({
           onFieldChange={(_, value) => handleCombinedPipelineChange(value)}
           multiple
           inputValue={combinedInputValue}
-          renderGroup={(params) => (
+          renderGroup={({ key, group, children }) => (
             <CollapsiblePipelineGroup
-              params={params}
+              key={key}
+              groupKey={key}
+              groupLabel={group}
               selectedPipelines={selectedPipelines}
               selectedVersions={selectedVersionsAll}
               onTogglePipeline={handleTogglePipeline}
-            />
+            >
+              {children}
+            </CollapsiblePipelineGroup>
           )}
         />
       </div>

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -156,6 +156,7 @@ function QueryForm({
               id: d.TermURL,
             }))}
             onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+            multiple
             inputValue={diagnosis}
           />
         </div>
@@ -181,6 +182,7 @@ function QueryForm({
           label="Assessment tool"
           options={assessmentOptions.map((a) => ({ label: a.Label as string, id: a.TermURL }))}
           onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+          multiple
           inputValue={assessmentTool}
         />
       </div>
@@ -192,6 +194,7 @@ function QueryForm({
             id: value.TermURL,
           }))}
           onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+          multiple
           inputValue={imagingModality}
         />
       </div>
@@ -204,37 +207,58 @@ function QueryForm({
             id: pipelineURI,
           }))}
           onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+          multiple
           inputValue={pipelineName}
         />
       </div>
-      {pipelineName === null ? (
-        <Tooltip
-          title={<Typography variant="body1">Please select a pipeline name</Typography>}
-          placement="right"
-        >
+      {(() => {
+        const selectedPipelines: FieldInputOption[] = Array.isArray(pipelineName)
+          ? pipelineName
+          : pipelineName
+            ? [pipelineName]
+            : [];
+
+        if (selectedPipelines.length === 0) {
+          return (
+            <Tooltip
+              title={<Typography variant="body1">Please select a pipeline name</Typography>}
+              placement="right"
+            >
+              <div>
+                <CategoricalField
+                  label="Pipeline version"
+                  options={[]}
+                  onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+                  multiple
+                  inputValue={null}
+                  disabled
+                />
+              </div>
+            </Tooltip>
+          );
+        }
+
+        const pipelineVersionOptions = selectedPipelines.flatMap((p) => {
+          const versions = pipelines[p.id] ?? [];
+          return versions.map((v) => ({
+            label: `${p.label} - ${v}`,
+            id: `${p.id}::${v}`,
+            group: p.label,
+          }));
+        });
+
+        return (
           <div>
             <CategoricalField
               label="Pipeline version"
-              options={[]}
+              options={pipelineVersionOptions}
               onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
-              inputValue={null}
-              disabled
+              multiple
+              inputValue={pipelineVersion}
             />
           </div>
-        </Tooltip>
-      ) : (
-        <div>
-          <CategoricalField
-            label="Pipeline version"
-            options={Object.values(pipelines[(pipelineName as FieldInputOption).id]).map((v) => ({
-              label: v,
-              id: v,
-            }))}
-            onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
-            inputValue={pipelineVersion}
-          />
-        </div>
-      )}
+        );
+      })()}
 
       <div className="flex justify-between">
         <Button

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -1,11 +1,23 @@
 import { useState } from 'react';
-import { Button, CircularProgress, FormHelperText, Tooltip, Typography } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  CircularProgress,
+  FormHelperText,
+  Typography,
+  AutocompleteRenderGroupParams,
+} from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { sexes } from '../utils/constants';
 import {
   NodeOption,
   AttributeOption,
   FieldInput,
+  FieldInputOption,
+  CategoricalFieldOption,
   Pipelines,
   ImagingModalityOption,
 } from '../utils/types';
@@ -13,6 +25,43 @@ import { parseNumericValue, normalizeFieldInputOptions } from '../utils/utils';
 import CategoricalField from './CategoricalField';
 import ContinuousField from './ContinuousField';
 import GetDataDialog from './GetDataDialog';
+
+function CollapsiblePipelineGroup(params: AutocompleteRenderGroupParams) {
+  return (
+    <li key={params.key}>
+      <Accordion
+        defaultExpanded
+        elevation={0}
+        square
+        disableGutters
+        sx={{
+          backgroundColor: 'transparent',
+          '&:before': { display: 'none' },
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon fontSize="small" />}
+          sx={{
+            minHeight: 36,
+            maxHeight: 36,
+            px: 2,
+            py: 0,
+            '&.Mui-expanded': { minHeight: 36, maxHeight: 36 },
+            '&:hover': { backgroundColor: 'action.hover' },
+            '.MuiAccordionSummary-content': { my: 0, '&.Mui-expanded': { my: 0 } },
+          }}
+        >
+          <Typography variant="body2" fontWeight={600}>
+            {params.group}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ p: 0 }}>
+          <ul>{params.children}</ul>
+        </AccordionDetails>
+      </Accordion>
+    </li>
+  );
+}
 
 function QueryForm({
   availableNodes,
@@ -97,6 +146,89 @@ function QueryForm({
     minAgeHelperText !== '' ||
     maxAgeHelperText !== '' ||
     minNumImagingSessionsHelperText !== '';
+
+  const pipelineCombinedOptions: CategoricalFieldOption[] = Object.keys(pipelines).flatMap(
+    (pId) => {
+      const pLabel = pId.startsWith('np:') ? pId.slice(3) : pId;
+      const versions = pipelines[pId] ?? [];
+
+      const pOptions: CategoricalFieldOption[] = [
+        {
+          label: `${pLabel} (Any version)`,
+          id: pId,
+          group: pLabel,
+        },
+      ];
+
+      versions.forEach((v) => {
+        pOptions.push({
+          label: `${pLabel} - ${v}`,
+          id: `${pId}::${v}`,
+          group: pLabel,
+        });
+      });
+
+      return pOptions;
+    }
+  );
+
+  const selectedPipelines = normalizeFieldInputOptions(pipelineName);
+  const selectedVersionsAll = normalizeFieldInputOptions(pipelineVersion);
+
+  const combinedInputValue: CategoricalFieldOption[] = selectedPipelines.flatMap((p) => {
+    const pVersions = selectedVersionsAll.filter((v) => v.id.startsWith(`${p.id}::`));
+    if (pVersions.length > 0) {
+      return pVersions.map((v) => ({
+        label: v.label,
+        id: v.id,
+        group: p.label,
+      }));
+    }
+    return [
+      {
+        label: `${p.label} (Any version)`,
+        id: p.id,
+        group: p.label,
+      },
+    ];
+  });
+
+  const handleCombinedPipelineChange = (selectedOptionsInput: FieldInput) => {
+    const selectedOptions = normalizeFieldInputOptions(selectedOptionsInput);
+
+    if (selectedOptions.length === 0) {
+      updateCategoricalQueryParams('Pipeline name', null);
+      updateCategoricalQueryParams('Pipeline version', null);
+      return;
+    }
+
+    const updatedPipelinesMap = new Map<string, FieldInputOption>();
+    const updatedVersions: FieldInputOption[] = [];
+
+    (selectedOptions as CategoricalFieldOption[]).forEach((opt) => {
+      if (opt.id.includes('::')) {
+        const pId = opt.id.split('::')[0];
+        const pLabel = opt.group ?? (pId.startsWith('np:') ? pId.slice(3) : pId);
+        updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
+        updatedVersions.push({ id: opt.id, label: opt.label });
+      } else {
+        const pId = opt.id;
+        const pLabel = opt.label.replace(' (Any version)', '');
+        updatedPipelinesMap.set(pId, { id: pId, label: pLabel });
+      }
+    });
+
+    const updatedPipelines = Array.from(updatedPipelinesMap.values());
+
+    updateCategoricalQueryParams(
+      'Pipeline name',
+      updatedPipelines.length > 0 ? updatedPipelines : null
+    );
+    updateCategoricalQueryParams(
+      'Pipeline version',
+      updatedVersions.length > 0 ? updatedVersions : null
+    );
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -199,61 +331,14 @@ function QueryForm({
       </div>
       <div>
         <CategoricalField
-          label="Pipeline name"
-          options={Object.keys(pipelines).map((pipelineURI) => ({
-            // Remove the `np:` prefix
-            label: pipelineURI.slice(3),
-            id: pipelineURI,
-          }))}
-          onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
+          label="Pipeline"
+          options={pipelineCombinedOptions}
+          onFieldChange={(_, value) => handleCombinedPipelineChange(value)}
           multiple
-          inputValue={pipelineName}
+          inputValue={combinedInputValue}
+          renderGroup={(params) => <CollapsiblePipelineGroup {...params} />}
         />
       </div>
-      {(() => {
-        const selectedPipelines = normalizeFieldInputOptions(pipelineName);
-
-        if (selectedPipelines.length === 0) {
-          return (
-            <Tooltip
-              title={<Typography variant="body1">Please select a pipeline name</Typography>}
-              placement="right"
-            >
-              <div>
-                <CategoricalField
-                  label="Pipeline version"
-                  options={[]}
-                  onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
-                  multiple
-                  inputValue={null}
-                  disabled
-                />
-              </div>
-            </Tooltip>
-          );
-        }
-
-        const pipelineVersionOptions = selectedPipelines.flatMap((p) => {
-          const versions = pipelines[p.id] ?? [];
-          return versions.map((v) => ({
-            label: `${p.label} - ${v}`,
-            id: `${p.id}::${v}`,
-            group: p.label,
-          }));
-        });
-
-        return (
-          <div>
-            <CategoricalField
-              label="Pipeline version"
-              options={pipelineVersionOptions}
-              onFieldChange={(label, value) => updateCategoricalQueryParams(label, value)}
-              multiple
-              inputValue={pipelineVersion}
-            />
-          </div>
-        );
-      })()}
 
       <div className="flex justify-between">
         <Button

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -391,7 +391,7 @@ function QueryForm({
       </div>
       <div>
         <CategoricalField
-          label="Pipeline"
+          label="Pipeline name and version"
           options={pipelineCombinedOptions}
           onFieldChange={(_, value) => handleCombinedPipelineChange(value)}
           multiple

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -76,6 +76,7 @@ function CollapsiblePipelineGroup({
           }}
         >
           <Checkbox
+            data-cy={`pipeline-group-${pId}-checkbox`}
             size="small"
             checked={isPipelineChecked}
             onClick={(e) => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -131,17 +131,21 @@ export interface SubjectsResponse extends BaseAPIResponse {
   responses: SubjectsResult[];
 }
 
+export interface PipelineQueryParam {
+  name: string;
+  version?: string;
+}
+
 export interface QueryParams {
   min_age?: number;
   max_age?: number;
   sex?: string;
-  diagnosis?: string;
+  diagnosis?: string[];
   min_num_imaging_sessions?: number;
   min_num_phenotypic_sessions?: number;
-  assessment?: string;
-  image_modal?: string;
-  pipeline_name?: string;
-  pipeline_version?: string;
+  assessment?: string[];
+  image_modal?: string[];
+  pipeline?: PipelineQueryParam[];
   nodes: Array<{ node_url: string }>;
 }
 
@@ -149,23 +153,27 @@ export interface SubjectsRequestBody {
   min_age?: number;
   max_age?: number;
   sex?: string;
-  diagnosis?: string;
+  diagnosis?: string[];
   min_num_imaging_sessions?: number;
   min_num_phenotypic_sessions?: number;
-  assessment?: string;
-  image_modal?: string;
-  pipeline_name?: string;
-  pipeline_version?: string;
+  assessment?: string[];
+  image_modal?: string[];
+  pipeline?: PipelineQueryParam[];
   nodes: Array<{ node_url: string; dataset_uuids: string[] }>;
+}
+
+export interface CategoricalFieldOption extends FieldInputOption {
+  group?: string;
 }
 
 export interface CategoricalFieldProps {
   label: string;
-  options: FieldInputOption[];
+  options: CategoricalFieldOption[];
   onFieldChange: (fieldLabel: string, value: FieldInput) => void;
   multiple?: boolean;
   inputValue: FieldInput;
   disabled?: boolean;
+  groupBy?: (option: CategoricalFieldOption) => string;
 }
 
 export type ToastProps = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -162,6 +162,8 @@ export interface SubjectsRequestBody {
   nodes: Array<{ node_url: string; dataset_uuids: string[] }>;
 }
 
+import { AutocompleteRenderGroupParams } from '@mui/material';
+
 export interface CategoricalFieldOption extends FieldInputOption {
   group?: string;
 }
@@ -174,6 +176,7 @@ export interface CategoricalFieldProps {
   inputValue: FieldInput;
   disabled?: boolean;
   groupBy?: (option: CategoricalFieldOption) => string;
+  renderGroup?: (params: AutocompleteRenderGroupParams) => React.ReactNode;
 }
 
 export type ToastProps = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -17,6 +17,9 @@ function normalizeFieldInput(input: FieldInput): string {
   }
 
   if (Array.isArray(input)) {
+    if (input.length === 0) {
+      return 'null';
+    }
     const ids = input.map((option) => option.id).sort();
     return `multi:${ids.join('|')}`;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { datasetsURL, subjectsURL } from './constants';
 import {
   FieldInput,
+  FieldInputOption,
   QueryFormState,
   QueryParams,
   DatasetsResponse,
@@ -10,6 +11,13 @@ import {
   SubjectsResponse,
   SubjectsQueryParams,
 } from './types';
+
+export function normalizeFieldInputOptions(input: FieldInput): FieldInputOption[] {
+  if (input === null) {
+    return [];
+  }
+  return Array.isArray(input) ? input : [input];
+}
 
 function normalizeFieldInput(input: FieldInput): string {
   if (input === null) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,6 +3,8 @@ import { datasetsURL, subjectsURL } from './constants';
 import {
   FieldInput,
   FieldInputOption,
+  CategoricalFieldOption,
+  Pipelines,
   QueryFormState,
   QueryParams,
   DatasetsResponse,
@@ -17,6 +19,70 @@ export function normalizeFieldInputOptions(input: FieldInput): FieldInputOption[
     return [];
   }
   return Array.isArray(input) ? input : [input];
+}
+
+export function validateContinuousValue(rawValue: string, parsedValue: number | null): string {
+  const trimmed = rawValue.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  if (parsedValue === null) {
+    return 'Please enter a valid number!';
+  }
+  if (parsedValue < 0) {
+    return 'Please enter a positive number!';
+  }
+  return '';
+}
+
+export function getPipelineLabel(pId: string): string {
+  return pId.startsWith('np:') ? pId.slice(3) : pId;
+}
+
+export function buildPipelineCombinedOptions(pipelines: Pipelines): CategoricalFieldOption[] {
+  return Object.keys(pipelines).flatMap((pId) => {
+    const pLabel = getPipelineLabel(pId);
+    const versions = pipelines[pId] ?? [];
+
+    if (versions.length === 0) {
+      return [
+        {
+          label: `${pLabel} any version`,
+          id: pId,
+          group: pLabel,
+        },
+      ];
+    }
+
+    return versions.map((v) => ({
+      label: `${pLabel} ${v}`,
+      id: `${pId}::${v}`,
+      group: pLabel,
+    }));
+  });
+}
+
+export function buildCombinedInputValue(
+  selectedPipelines: FieldInputOption[],
+  selectedVersionsAll: FieldInputOption[]
+): CategoricalFieldOption[] {
+  return selectedPipelines.flatMap((p) => {
+    const pVersions = selectedVersionsAll.filter((v) => v.id.startsWith(`${p.id}::`));
+    if (pVersions.length > 0) {
+      return pVersions.map((v) => ({
+        label: v.label,
+        id: v.id,
+        group: p.label,
+      }));
+    }
+    return [
+      {
+        label: `${p.label} any version`,
+        id: p.id,
+        group: p.label,
+      },
+    ];
+  });
 }
 
 function normalizeFieldInput(input: FieldInput): string {


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #832

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
  - Enabled multi-selection across diagnosis, assessment, imagingModality, and pipeline fields.
  - Combined separate Pipeline Name and Pipeline Version inputs into a single "Pipeline name and version" collapsible tree-select dropdown, collapsed by default.
  - Formatted pipeline group header selections to display as `<Pipeline Name> any version` chip pills (e.g., `fmriprep any version`).
  - Configured header unchecking to automatically deselect child pipeline versions.
  - Updated `constructDatasetsRequestBody` in `src/App.tsx` and API payload types to format multi-select fields (diagnosis, assessment, image_modal, pipeline) as array payloads.
  - Refactored form logic by extracting `CollapsiblePipelineGroup` into a standalone component with explicit props (`groupKey`, `groupLabel`, `children`).
  - Centralized pure pipeline option transformers and numeric validation helpers in `src/utils/utils.ts`.
  - Added dedicated Cypress component tests for `CollapsiblePipelineGroup` (`CollapsiblePipelineGroup.cy.tsx`) and updated existing component and E2E test suites (`Form.cy.ts`, `APIRequests.cy.ts`, `QueryForm.cy.tsx`).


<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the participant-level and/or the dataset-level result file, the [`query-tool-results` files](https://github.com/neurobagel/neurobagel_examples/tree/main/query-tool-results) in the  [neurobagel_examples repo](https://github.com/neurobagel/neurobagel_examples/) have been regenerated

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhance query filtering with multi-select categorical fields and a unified grouped pipeline name/version selector.

New Features:
- Combine pipeline names and versions into a grouped, multi-select query field with support for selecting any version or specific versions.
- Support multiple selections for diagnosis, assessment tools, and imaging modalities.

Bug Fixes:
- Preserve valid pipeline version selections when pipeline selections change and clear incompatible versions.

Enhancements:
- Update query construction to submit categorical filters as arrays and pipelines as name/version pairs.
- Load pipeline versions for all available pipelines and provide collapsible pipeline groups with checkbox controls.

Tests:
- Add component and end-to-end coverage for multi-select categorical fields, grouped pipeline selection, query payloads, clearing selections, and pipeline version loading.

## Summary by Sourcery

Enable multi-value query filtering with a unified pipeline name and version selector.

New Features:
- Enable multi-selection for diagnosis, assessment, and imaging modality query filters.
- Provide a unified grouped pipeline name and version selector supporting any-version and specific-version choices.

Bug Fixes:
- Clear incompatible pipeline version selections when their pipeline is deselected or changed.

Enhancements:
- Submit multi-select categorical filters as arrays and pipeline filters as name/version query objects.
- Load pipeline versions across available pipelines and present them in collapsible grouped selections.

Tests:
- Add component and end-to-end coverage for multi-select fields, grouped pipeline selection, query payloads, and selection clearing.